### PR TITLE
feat : OAuth 인증 로직 구현 및 jwt 토큰 시스템 구축

### DIFF
--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DBNavigator.Project.DDLFileAttachmentManager">
+    <mappings />
+    <preferences />
+  </component>
+  <component name="DBNavigator.Project.DataEditorManager">
+    <record-view-column-sorting-type value="BY_INDEX" />
+    <value-preview-text-wrapping value="false" />
+    <value-preview-pinned value="false" />
+  </component>
+  <component name="DBNavigator.Project.DatabaseBrowserManager">
+    <autoscroll-to-editor value="false" />
+    <autoscroll-from-editor value="true" />
+    <show-object-properties value="true" />
+    <loaded-nodes />
+  </component>
+  <component name="DBNavigator.Project.DatabaseEditorStateManager">
+    <last-used-providers />
+  </component>
+  <component name="DBNavigator.Project.DatabaseFileManager">
+    <open-files />
+  </component>
+  <component name="DBNavigator.Project.ExecutionManager">
+    <retain-sticky-names value="false" />
+  </component>
+  <component name="DBNavigator.Project.Settings">
+    <connections />
+    <browser-settings>
+      <general>
+        <display-mode value="TABBED" />
+        <navigation-history-size value="100" />
+        <show-object-details value="false" />
+        <enable-sticky-paths value="true" />
+      </general>
+      <filters>
+        <object-type-filter>
+          <object-type name="SCHEMA" enabled="true" />
+          <object-type name="USER" enabled="true" />
+          <object-type name="ROLE" enabled="true" />
+          <object-type name="PRIVILEGE" enabled="true" />
+          <object-type name="CHARSET" enabled="true" />
+          <object-type name="TABLE" enabled="true" />
+          <object-type name="VIEW" enabled="true" />
+          <object-type name="MATERIALIZED_VIEW" enabled="true" />
+          <object-type name="NESTED_TABLE" enabled="true" />
+          <object-type name="COLUMN" enabled="true" />
+          <object-type name="INDEX" enabled="true" />
+          <object-type name="CONSTRAINT" enabled="true" />
+          <object-type name="DATASET_TRIGGER" enabled="true" />
+          <object-type name="DATABASE_TRIGGER" enabled="true" />
+          <object-type name="SYNONYM" enabled="true" />
+          <object-type name="SEQUENCE" enabled="true" />
+          <object-type name="PROCEDURE" enabled="true" />
+          <object-type name="FUNCTION" enabled="true" />
+          <object-type name="PACKAGE" enabled="true" />
+          <object-type name="TYPE" enabled="true" />
+          <object-type name="TYPE_ATTRIBUTE" enabled="true" />
+          <object-type name="ARGUMENT" enabled="true" />
+          <object-type name="DIMENSION" enabled="true" />
+          <object-type name="CLUSTER" enabled="true" />
+          <object-type name="DBLINK" enabled="true" />
+        </object-type-filter>
+      </filters>
+      <sorting>
+        <object-type name="COLUMN" sorting-type="NAME" />
+        <object-type name="FUNCTION" sorting-type="NAME" />
+        <object-type name="PROCEDURE" sorting-type="NAME" />
+        <object-type name="ARGUMENT" sorting-type="POSITION" />
+        <object-type name="TYPE ATTRIBUTE" sorting-type="POSITION" />
+      </sorting>
+      <default-editors>
+        <object-type name="VIEW" editor-type="SELECTION" />
+        <object-type name="PACKAGE" editor-type="SELECTION" />
+        <object-type name="TYPE" editor-type="SELECTION" />
+      </default-editors>
+    </browser-settings>
+    <navigation-settings>
+      <lookup-filters>
+        <lookup-objects>
+          <object-type name="SCHEMA" enabled="true" />
+          <object-type name="USER" enabled="false" />
+          <object-type name="ROLE" enabled="false" />
+          <object-type name="PRIVILEGE" enabled="false" />
+          <object-type name="CHARSET" enabled="false" />
+          <object-type name="TABLE" enabled="true" />
+          <object-type name="VIEW" enabled="true" />
+          <object-type name="MATERIALIZED VIEW" enabled="true" />
+          <object-type name="INDEX" enabled="true" />
+          <object-type name="CONSTRAINT" enabled="true" />
+          <object-type name="DATASET TRIGGER" enabled="true" />
+          <object-type name="DATABASE TRIGGER" enabled="true" />
+          <object-type name="SYNONYM" enabled="false" />
+          <object-type name="SEQUENCE" enabled="true" />
+          <object-type name="PROCEDURE" enabled="true" />
+          <object-type name="FUNCTION" enabled="true" />
+          <object-type name="PACKAGE" enabled="true" />
+          <object-type name="TYPE" enabled="true" />
+          <object-type name="DIMENSION" enabled="false" />
+          <object-type name="CLUSTER" enabled="false" />
+          <object-type name="DBLINK" enabled="true" />
+        </lookup-objects>
+        <force-database-load value="false" />
+        <prompt-connection-selection value="true" />
+        <prompt-schema-selection value="true" />
+      </lookup-filters>
+    </navigation-settings>
+    <dataset-grid-settings>
+      <general>
+        <enable-zooming value="true" />
+        <enable-column-tooltip value="true" />
+      </general>
+      <sorting>
+        <nulls-first value="true" />
+        <max-sorting-columns value="4" />
+      </sorting>
+      <audit-columns>
+        <column-names value="" />
+        <visible value="true" />
+        <editable value="false" />
+      </audit-columns>
+    </dataset-grid-settings>
+    <dataset-editor-settings>
+      <text-editor-popup>
+        <active value="false" />
+        <active-if-empty value="false" />
+        <data-length-threshold value="100" />
+        <popup-delay value="1000" />
+      </text-editor-popup>
+      <values-actions-popup>
+        <show-popup-button value="true" />
+        <element-count-threshold value="1000" />
+        <data-length-threshold value="250" />
+      </values-actions-popup>
+      <general>
+        <fetch-block-size value="100" />
+        <fetch-timeout value="30" />
+        <trim-whitespaces value="true" />
+        <convert-empty-strings-to-null value="true" />
+        <select-content-on-cell-edit value="true" />
+        <large-value-preview-active value="true" />
+      </general>
+      <filters>
+        <prompt-filter-dialog value="true" />
+        <default-filter-type value="BASIC" />
+      </filters>
+      <qualified-text-editor text-length-threshold="300">
+        <content-types>
+          <content-type name="Text" enabled="true" />
+          <content-type name="Properties" enabled="true" />
+          <content-type name="XML" enabled="true" />
+          <content-type name="DTD" enabled="true" />
+          <content-type name="HTML" enabled="true" />
+          <content-type name="XHTML" enabled="true" />
+          <content-type name="Java" enabled="true" />
+          <content-type name="SQL" enabled="true" />
+          <content-type name="PL/SQL" enabled="true" />
+          <content-type name="JSON" enabled="true" />
+          <content-type name="JSON5" enabled="true" />
+          <content-type name="Groovy" enabled="true" />
+          <content-type name="YAML" enabled="true" />
+          <content-type name="Manifest" enabled="true" />
+        </content-types>
+      </qualified-text-editor>
+      <record-navigation>
+        <navigation-target value="VIEWER" />
+      </record-navigation>
+    </dataset-editor-settings>
+    <code-editor-settings>
+      <general>
+        <show-object-navigation-gutter value="false" />
+        <show-spec-declaration-navigation-gutter value="true" />
+        <enable-spellchecking value="true" />
+        <enable-reference-spellchecking value="false" />
+      </general>
+      <confirmations>
+        <save-changes value="false" />
+        <revert-changes value="true" />
+        <exit-on-changes value="ASK" />
+      </confirmations>
+    </code-editor-settings>
+    <code-completion-settings>
+      <filters>
+        <basic-filter>
+          <filter-element type="RESERVED_WORD" id="keyword" selected="true" />
+          <filter-element type="RESERVED_WORD" id="function" selected="true" />
+          <filter-element type="RESERVED_WORD" id="parameter" selected="true" />
+          <filter-element type="RESERVED_WORD" id="datatype" selected="true" />
+          <filter-element type="RESERVED_WORD" id="exception" selected="true" />
+          <filter-element type="OBJECT" id="schema" selected="true" />
+          <filter-element type="OBJECT" id="role" selected="true" />
+          <filter-element type="OBJECT" id="user" selected="true" />
+          <filter-element type="OBJECT" id="privilege" selected="true" />
+          <user-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="false" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </user-schema>
+          <public-schema>
+            <filter-element type="OBJECT" id="table" selected="false" />
+            <filter-element type="OBJECT" id="view" selected="false" />
+            <filter-element type="OBJECT" id="materialized view" selected="false" />
+            <filter-element type="OBJECT" id="index" selected="false" />
+            <filter-element type="OBJECT" id="constraint" selected="false" />
+            <filter-element type="OBJECT" id="trigger" selected="false" />
+            <filter-element type="OBJECT" id="synonym" selected="false" />
+            <filter-element type="OBJECT" id="sequence" selected="false" />
+            <filter-element type="OBJECT" id="procedure" selected="false" />
+            <filter-element type="OBJECT" id="function" selected="false" />
+            <filter-element type="OBJECT" id="package" selected="false" />
+            <filter-element type="OBJECT" id="type" selected="false" />
+            <filter-element type="OBJECT" id="dimension" selected="false" />
+            <filter-element type="OBJECT" id="cluster" selected="false" />
+            <filter-element type="OBJECT" id="dblink" selected="false" />
+          </public-schema>
+          <any-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </any-schema>
+        </basic-filter>
+        <extended-filter>
+          <filter-element type="RESERVED_WORD" id="keyword" selected="true" />
+          <filter-element type="RESERVED_WORD" id="function" selected="true" />
+          <filter-element type="RESERVED_WORD" id="parameter" selected="true" />
+          <filter-element type="RESERVED_WORD" id="datatype" selected="true" />
+          <filter-element type="RESERVED_WORD" id="exception" selected="true" />
+          <filter-element type="OBJECT" id="schema" selected="true" />
+          <filter-element type="OBJECT" id="user" selected="true" />
+          <filter-element type="OBJECT" id="role" selected="true" />
+          <filter-element type="OBJECT" id="privilege" selected="true" />
+          <user-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </user-schema>
+          <public-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </public-schema>
+          <any-schema>
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
+          </any-schema>
+        </extended-filter>
+      </filters>
+      <sorting enabled="true">
+        <sorting-element type="RESERVED_WORD" id="keyword" />
+        <sorting-element type="RESERVED_WORD" id="datatype" />
+        <sorting-element type="OBJECT" id="column" />
+        <sorting-element type="OBJECT" id="table" />
+        <sorting-element type="OBJECT" id="view" />
+        <sorting-element type="OBJECT" id="materialized view" />
+        <sorting-element type="OBJECT" id="index" />
+        <sorting-element type="OBJECT" id="constraint" />
+        <sorting-element type="OBJECT" id="trigger" />
+        <sorting-element type="OBJECT" id="synonym" />
+        <sorting-element type="OBJECT" id="sequence" />
+        <sorting-element type="OBJECT" id="procedure" />
+        <sorting-element type="OBJECT" id="function" />
+        <sorting-element type="OBJECT" id="package" />
+        <sorting-element type="OBJECT" id="type" />
+        <sorting-element type="OBJECT" id="dimension" />
+        <sorting-element type="OBJECT" id="cluster" />
+        <sorting-element type="OBJECT" id="dblink" />
+        <sorting-element type="OBJECT" id="schema" />
+        <sorting-element type="OBJECT" id="role" />
+        <sorting-element type="OBJECT" id="user" />
+        <sorting-element type="RESERVED_WORD" id="function" />
+        <sorting-element type="RESERVED_WORD" id="parameter" />
+      </sorting>
+      <format>
+        <enforce-code-style-case value="true" />
+      </format>
+    </code-completion-settings>
+    <execution-engine-settings>
+      <statement-execution>
+        <fetch-block-size value="100" />
+        <execution-timeout value="20" />
+        <debug-execution-timeout value="600" />
+        <focus-result value="false" />
+        <prompt-execution value="false" />
+      </statement-execution>
+      <script-execution>
+        <command-line-interfaces />
+        <execution-timeout value="300" />
+      </script-execution>
+      <method-execution>
+        <execution-timeout value="30" />
+        <debug-execution-timeout value="600" />
+        <parameter-history-size value="10" />
+      </method-execution>
+    </execution-engine-settings>
+    <operation-settings>
+      <transactions>
+        <uncommitted-changes>
+          <on-project-close value="ASK" />
+          <on-disconnect value="ASK" />
+          <on-autocommit-toggle value="ASK" />
+        </uncommitted-changes>
+        <multiple-uncommitted-changes>
+          <on-commit value="ASK" />
+          <on-rollback value="ASK" />
+        </multiple-uncommitted-changes>
+      </transactions>
+      <session-browser>
+        <disconnect-session value="ASK" />
+        <kill-session value="ASK" />
+        <reload-on-filter-change value="false" />
+      </session-browser>
+      <compiler>
+        <compile-type value="KEEP" />
+        <compile-dependencies value="ASK" />
+        <always-show-controls value="false" />
+      </compiler>
+    </operation-settings>
+    <ddl-file-settings>
+      <extensions>
+        <mapping file-type-id="VIEW" extensions="vw" />
+        <mapping file-type-id="TRIGGER" extensions="trg" />
+        <mapping file-type-id="PROCEDURE" extensions="prc" />
+        <mapping file-type-id="FUNCTION" extensions="fnc" />
+        <mapping file-type-id="PACKAGE" extensions="pkg" />
+        <mapping file-type-id="PACKAGE_SPEC" extensions="pks" />
+        <mapping file-type-id="PACKAGE_BODY" extensions="pkb" />
+        <mapping file-type-id="TYPE" extensions="tpe" />
+        <mapping file-type-id="TYPE_SPEC" extensions="tps" />
+        <mapping file-type-id="TYPE_BODY" extensions="tpb" />
+      </extensions>
+      <general>
+        <lookup-ddl-files value="true" />
+        <create-ddl-files value="false" />
+        <synchronize-ddl-files value="true" />
+        <use-qualified-names value="false" />
+        <make-scripts-rerunnable value="true" />
+      </general>
+    </ddl-file-settings>
+    <general-settings>
+      <regional-settings>
+        <date-format value="MEDIUM" />
+        <number-format value="UNGROUPED" />
+        <locale value="SYSTEM_DEFAULT" />
+        <use-custom-formats value="false" />
+      </regional-settings>
+      <environment>
+        <environment-types>
+          <environment-type id="development" name="Development" description="Development environment" color="-2430209/-12296320" readonly-code="false" readonly-data="false" />
+          <environment-type id="integration" name="Integration" description="Integration environment" color="-2621494/-12163514" readonly-code="true" readonly-data="false" />
+          <environment-type id="production" name="Production" description="Productive environment" color="-11574/-10271420" readonly-code="true" readonly-data="true" />
+          <environment-type id="other" name="Other" description="" color="-1576/-10724543" readonly-code="false" readonly-data="false" />
+        </environment-types>
+        <visibility-settings>
+          <connection-tabs value="true" />
+          <dialog-headers value="true" />
+          <object-editor-tabs value="true" />
+          <script-editor-tabs value="false" />
+          <execution-result-tabs value="true" />
+        </visibility-settings>
+      </environment>
+    </general-settings>
+  </component>
+  <component name="DBNavigator.Project.StatementExecutionManager">
+    <execution-variables />
+    <execution-variable-types />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$/Backend" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="gradleJvm" value="temurin-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/Backend" />

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/HappyMeal.iml" filepath="$PROJECT_DIR$/.idea/HappyMeal.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/demo.main.iml" filepath="$PROJECT_DIR$/.idea/modules/demo.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+##apiKey##
+.env

--- a/Backend/build.gradle
+++ b/Backend/build.gradle
@@ -25,11 +25,12 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 	implementation 'org.springframework.session:spring-session-core'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -39,6 +40,11 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 //	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // 또는 최신 버전
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'  // 또는 jjwt-api와 버전 일치
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // 또는 jjwt-api와 버전 일치 (Jackson 사용 시)
 }
 
 tasks.named('test') {

--- a/Backend/data/schema.sql
+++ b/Backend/data/schema.sql
@@ -4,15 +4,16 @@ CREATE DATABASE IF NOT EXISTS nyamnyam;
 USE nyamnyam;
 -- MySQL 기준 SQL 문 (Google 로그인 반영, ENUM 타입, 수정된 FK, 컬럼 제약조건 수정, MealLog.img_url 추가)
 
--- 사용자 정보 테이블 (Google OAuth2 기반)
+-- 사용자 정보 테이블 (password 삭제, role 변경, profile_image_url 추가)
 CREATE TABLE User (
-                      user_id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '사용자 고유 내부 PK ID',
-                      google_id VARCHAR(255) NOT NULL UNIQUE COMMENT 'Google 사용자 고유 ID (sub)',
-                      email VARCHAR(255) UNIQUE COMMENT '사용자 이메일 (Google 제공)',
-                      nickname VARCHAR(50) NOT NULL UNIQUE COMMENT '사용자 닉네임 (Unique)',
-                      role ENUM('USER', 'ADMIN') NOT NULL DEFAULT 'USER' COMMENT '사용자 권한',
-                      password VARCHAR(255) NULL COMMENT '비밀번호 (향후 다른 로그인 방식 또는 관리자용)',
-                      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '가입 일시'
+    user_id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '사용자 고유 내부 PK ID',
+    google_id VARCHAR(255) NOT NULL UNIQUE COMMENT 'Google 사용자 고유 ID (sub)',
+    email VARCHAR(255) UNIQUE COMMENT '사용자 이메일 (Google 제공, Null 허용)',
+    nickname VARCHAR(50) NOT NULL COMMENT '사용자 닉네임 (Unique)',
+    role VARCHAR(20) NOT NULL DEFAULT 'ROLE_USER' COMMENT '사용자 권한 (String 타입, 예: ROLE_USER, ROLE_ADMIN)',
+    profile_image_url VARCHAR(512) NULL COMMENT '사용자 프로필 이미지 URL', -- 추가됨
+    -- password 컬럼 삭제됨
+    create_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '가입 일시'
 ) ENGINE=InnoDB COMMENT '사용자 정보';
 
 -- 음식 영양 정보 테이블 (컬럼 제약조건 수정됨)

--- a/Backend/src/main/java/com/ssafy/HappyMealApplication.java
+++ b/Backend/src/main/java/com/ssafy/HappyMealApplication.java
@@ -1,9 +1,11 @@
 package com.ssafy;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@MapperScan("com.ssafy.happymeal.domain.user.dao")
 public class HappyMealApplication {
 
 	public static void main(String[] args) {

--- a/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
@@ -1,0 +1,136 @@
+package com.ssafy.happymeal.config; // 프로젝트 패키지 구조에 맞게 수정하세요
+
+import com.ssafy.happymeal.security.jwt.JwtAuthenticationFilter;
+import com.ssafy.happymeal.security.jwt.JwtTokenProvider;
+import com.ssafy.happymeal.security.jwt.JwtAccessDeniedHandler;
+import com.ssafy.happymeal.security.jwt.JwtAuthenticationEntryPoint;
+import com.ssafy.happymeal.domain.user.service.CustomOAuth2UserService;
+import com.ssafy.happymeal.security.jwt.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity // Spring Security 활성화
+@RequiredArgsConstructor // Lombok: final 필드 생성자 주입
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // 1. 기본 설정 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // Form Login 비활성화
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (Stateless JWT 사용 시)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션을 사용하지 않음 (Stateless)
+                )
+
+                // 2. CORS 설정 (아래 corsConfigurationSource Bean 사용)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // 3. 인가(Authorization) 규칙 설정
+                .authorizeHttpRequests(authorize -> authorize
+                        // 명세서 기반 경로별 접근 권한 설정
+                        .requestMatchers(
+                                "/", // 루트
+                                "/error", // 에러 페이지
+                                "/favicon.ico",
+                                "/css/**", "/js/**", "/images/**", // 정적 리소스
+                                "/api/auth/**", // 인증 관련 API (로그인 시작, 콜백 등)
+                                "/api/foods", // 음식 검색 (GET) - 명세상 모든 사용자 접근 가능
+                                "/api/foods/{foodId}", // 음식 상세 조회 (GET) - 명세상 모든 사용자 접근 가능
+                                "/api/board", // 게시판 목록 조회 (GET)
+                                "/api/board/{postId}" // 게시판 상세 조회 (GET)
+                                // 필요시 h2-console 접근 허용 (개발용)
+                                // , "/h2-console/**"
+                        ).permitAll() // 위 경로는 인증 없이 접근 허용
+
+                        .requestMatchers("/api/admin/**", "/api/foods/**") // 관리자 기능 및 음식 정보 관리(추가/수정/삭제)
+                        .hasRole("ADMIN") // ADMIN 역할 필요
+
+                        .requestMatchers(
+                                "/api/users/me/**", // 내 정보 관련
+                                "/api/meallogs/**", // 식단 기록 관련
+                                "/api/food-requests", // 음식 요청 (POST)
+                                "/api/board" // 게시글 작성(POST), 수정(PUT), 삭제(DELETE) - 세부 검증은 컨트롤러/서비스에서
+                        ).hasAnyRole("USER", "ADMIN") // USER 또는 ADMIN 역할 필요
+
+                        // 나머지 모든 요청은 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                // 4. OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                                // .loginPage("/login") // 커스텀 로그인 페이지 (필요 시)
+                                // OAuth2 로그인 성공 후 처리 로직
+                                .userInfoEndpoint(userInfo -> userInfo
+                                        .userService(customOAuth2UserService) // 사용자 정보 처리 서비스
+                                )
+                                .successHandler(oAuth2LoginSuccessHandler) // 로그인 성공 핸들러 (JWT 발급)
+                        // .failureHandler(oAuth2LoginFailureHandler) // 로그인 실패 핸들러 (선택 사항)
+                )
+
+                // 5. JWT 인증 필터 추가
+                // UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter를 실행
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+
+                // 6. 예외 처리 설정
+                .exceptionHandling(exceptions -> exceptions
+                        .accessDeniedHandler(jwtAccessDeniedHandler) // 인가 실패 시 처리 (403)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint) // 인증 실패 시 처리 (401)
+
+                );
+
+
+        // H2 Console 사용 시 frameOptions 비활성화 (개발 환경에서만 사용)
+        // http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
+
+        return http.build();
+    }
+
+    // CORS 설정 Bean (React 연동 시 필요)
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // TODO: 실제 배포 시에는 프론트엔드 서버 주소만 허용하도록 수정해야 합니다.
+        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // 예: React 개발 서버 주소
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
+        configuration.setAllowedHeaders(Arrays.asList(
+                "Authorization", // JWT 인증 헤더
+                "Cache-Control",
+                "Content-Type" // 요청/응답 컨텐츠 타입
+        ));
+        configuration.setAllowCredentials(true); // 자격 증명(쿠키 등) 허용
+        configuration.setMaxAge(3600L); // pre-flight 요청 캐시 시간 (초)
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration); // /api/** 경로에 대해 위 설정 적용
+        return source;
+    }
+
+    // PasswordEncoder Bean (Google 로그인만 사용하면 당장은 필요 없지만, 향후 확장 고려)
+    // @Bean
+    // public PasswordEncoder passwordEncoder() {
+    //     return new BCryptPasswordEncoder();
+    // }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dao/UserDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dao/UserDAO.java
@@ -1,4 +1,37 @@
 package com.ssafy.happymeal.domain.user.dao;
 
-public class UserDAO {
+import com.ssafy.happymeal.domain.user.entity.User;
+import org.apache.ibatis.annotations.*;
+
+import java.util.Optional;
+
+@Mapper
+public interface UserDAO {
+
+    // 로그인을 위한 User google 아이디를 가져오기
+    @Select("select * " +
+            "from User " +
+            "where google_id=#{googleId}")
+    Optional<User> findByGoogleId(String googleId);
+
+    // User 조회
+    @Select("select * " +
+            "from User " +
+            "where user_id=#{userId}"
+    )
+    Optional<User> findById(String userId);
+
+    // User 정보 저장
+    @Insert("insert into User(google_id, email, nickname, role, profile_image_url, create_at)"
+            + " values(#{googleId}, #{email}, #{nickname}, #{role}, #{profileImageUrl}, NOW())"
+    )
+    @Options(useGeneratedKeys = true, keyProperty = "userId", keyColumn = "user_id")
+    int save(User user);
+
+    // User 정보 수정
+    @Update("update User"
+            + " set nickname=#{nickname}, profile_image_url=#{profileImageUrl}"
+            + " where user_id=#{userId}"
+    )
+    int update(User user);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/OAuthAttributes.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/OAuthAttributes.java
@@ -1,0 +1,85 @@
+package com.ssafy.happymeal.domain.user.dto; // 패키지 경로는 실제 프로젝트에 맞게 조정하세요
+
+// import com.ssafy.happymeal.domain.user.Role; // Role Enum 대신 String 사용
+import com.ssafy.happymeal.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+/**
+ * OAuth2 인증 과정에서 얻은 사용자 속성(attributes)을 담고 처리하는 DTO 클래스.
+ * - profileImageUrl 필드 추가 반영
+ * - role 타입을 String으로 처리 반영
+ */
+@Slf4j
+@Getter
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String googleId;
+    private String nickname;
+    private String email;
+    private String picture; // Google 프로필 사진 URL ('picture' 속성)
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String googleId, String nickname, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.googleId = googleId;
+        this.nickname = nickname;
+        this.email = email;
+        this.picture = picture; // picture 필드 초기화 추가
+    }
+
+    /**
+     * OAuth2 공급자 정보와 속성을 기반으로 OAuthAttributes 객체를 생성합니다.
+     */
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        log.debug("Creating OAuthAttributes for registrationId: {}", registrationId);
+        if ("google".equals(registrationId)) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+        // 다른 소셜 로그인 추가 시 여기에 분기
+        log.error("Unsupported registrationId: {}", registrationId);
+        return null;
+    }
+
+    /**
+     * Google 속성을 기반으로 OAuthAttributes 객체를 생성합니다.
+     * 'picture' 속성을 추가로 추출합니다.
+     */
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        log.debug("Parsing Google attributes. Key for ID: {}", userNameAttributeName);
+        return OAuthAttributes.builder()
+                .googleId((String) attributes.get(userNameAttributeName)) // "sub"
+                .nickname((String) attributes.get("name"))      // "name"
+                .email((String) attributes.get("email"))        // "email"
+                .picture((String) attributes.get("picture"))    // "picture" 추가
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    /**
+     * OAuthAttributes 정보를 바탕으로 User 엔티티 객체를 생성합니다.
+     * - profileImageUrl 필드 매핑 추가
+     * - role 필드를 String("ROLE_USER")으로 설정
+     *
+     * @return 생성된 User 엔티티 객체 (DB 저장 전 상태)
+     */
+    public User toEntity() {
+        log.debug("Converting OAuthAttributes to User entity for googleId: {}", googleId);
+        return User.builder()
+                .googleId(this.googleId)
+                .nickname(this.nickname)
+                .email(this.email)
+                .profileImageUrl(this.picture) // picture 필드를 profileImageUrl에 매핑
+                .role("USER")           // Role Enum 대신 String "ROLE_USER" 사용
+                // password 필드는 null
+                // userId, createdAt 필드는 설정하지 않음 (DB에서 처리)
+                .build();
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserDto.java
@@ -1,0 +1,26 @@
+package com.ssafy.happymeal.domain.user.dto;
+
+import com.ssafy.happymeal.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UserDto {
+    private Long userId;
+    private String nickName;
+    private String email;
+    private String role;
+
+
+    public static UserDto fromEntity(User user) {
+        return UserDto.builder()
+                .userId(user.getUserId())
+                .nickName(user.getNickname())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserRequestDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserRequestDto.java
@@ -1,4 +1,0 @@
-package com.ssafy.happymeal.domain.user.dto;
-
-public class UserRequestDto {
-}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserResponseDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dto/UserResponseDto.java
@@ -1,4 +1,0 @@
-package com.ssafy.happymeal.domain.user.dto;
-
-public class UserResponseDto {
-}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/entity/User.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/entity/User.java
@@ -1,90 +1,39 @@
 package com.ssafy.happymeal.domain.user.entity;
 
+import lombok.*;
+
 import java.sql.Timestamp;
 
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
+
     private Long userId;
-    private String id;
-    private String password;
+    private String googleId;
+    private String email;
     private String nickname;
     private String role;
+    private String profileImageUrl;
     private Timestamp createAt;
 
-    public User() {
-    }
+//    public User() {
+//    }
 
-    public User(String id, String password, String nickname) {
-        this.id = id;
-        this.password = password;
+    public User(String nickname, String profileImageUrl) {
         this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
     }
 
-    public User(Long userId, String id, String password, String nickname, String role, Timestamp createAt) {
-        this.userId = userId;
-        this.id = id;
-        this.password = password;
+    public User updateOAuthInfo(String nickname, String email, String profileImageUrl) {
         this.nickname = nickname;
-        this.role = role;
-        this.createAt = createAt;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl; // 프로필 이미지 URL 업데이트 추가
+        // this.lastLoginAt = LocalDateTime.now(); // 마지막 로그인 시간 업데이트 로직 (필요하다면)
+        return this;
     }
 
-    public Timestamp getCreateAt() {
-        return createAt;
-    }
-
-    public void setCreateAt(Timestamp createAt) {
-        this.createAt = createAt;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
-
-    public void setUserId(Long userId) {
-        this.userId = userId;
-    }
-
-    @Override
-    public String toString() {
-        return "User{" +
-                "createAt=" + createAt +
-                ", userId=" + userId +
-                ", id='" + id + '\'' +
-                ", password='" + password + '\'' +
-                ", nickname='" + nickname + '\'' +
-                ", role='" + role + '\'' +
-                '}';
-    }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/service/CustomOAuth2UserService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,125 @@
+package com.ssafy.happymeal.domain.user.service; // OAuth 관련 클래스 패키지 경로 예시
+
+import com.ssafy.happymeal.domain.user.dao.UserDAO;
+import com.ssafy.happymeal.domain.user.entity.User;
+import com.ssafy.happymeal.domain.user.dto.OAuthAttributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j; // 로깅을 위한 Lombok 어노테이션
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // DB 작업을 위한 트랜잭션
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Google OAuth2 로그인 성공 후 사용자 정보를 처리하는 서비스.
+ * DefaultOAuth2UserService를 확장하여 구현합니다.
+ */
+@Slf4j // 로그 사용을 위한 Lombok 어노테이션
+@Service
+@RequiredArgsConstructor
+@Transactional // 이 서비스 내의 메소드는 DB 작업 시 트랜잭션 안에서 실행됩니다.
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserDAO userDAO; // MyBatis Mapper(DAO) 주입
+
+    /**
+     * OAuth2 공급자(Google)로부터 사용자 정보를 받아온 후 호출됩니다.
+     * 사용자 정보를 기반으로 DB에서 사용자를 찾거나 새로 생성하고,
+     * 인증된 사용자 정보를 나타내는 OAuth2User 객체를 반환합니다.
+     *
+     * @param userRequest OAuth2 사용자 정보 요청 객체
+     * @return 인증된 사용자 정보를 담은 OAuth2User 객체
+     * @throws OAuth2AuthenticationException 인증 처리 중 예외 발생 시
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.debug("OAuth2UserRequest received: {}", userRequest);
+
+        // 1. 기본 OAuth2UserService를 사용하여 사용자 정보 로드
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        log.debug("OAuth2User loaded from provider: {}", oAuth2User.getAttributes());
+
+        // 2. 현재 로그인 진행 중인 서비스(provider) ID 확인 (예: "google")
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.debug("Registration ID: {}", registrationId);
+
+        // 3. OAuth2 로그인 시 키가 되는 필드값(Primary Key 역할) 확인 (Google: "sub")
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        log.debug("User name attribute name: {}", userNameAttributeName);
+
+        // 4. OAuth2UserService를 통해 가져온 OAuth2User의 attribute들을 DTO로 변환
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, attributes);
+        log.debug("Parsed OAuthAttributes: googleId={}, nickname={}, email={}",
+                oAuthAttributes.getGoogleId(), oAuthAttributes.getNickname(), oAuthAttributes.getEmail());
+
+        // 5. DB에서 사용자 조회 또는 저장
+        User user = saveOrUpdate(oAuthAttributes);
+        log.info("User processed: userId={}, googleId={}, nickname={}, role={}",
+                user.getUserId(), user.getGoogleId(), user.getNickname(), user.getRole());
+
+        // 6. 인증된 사용자 정보를 담은 Principal 객체(DefaultOAuth2User) 반환
+        //    Spring Security Context에 저장되어 인증된 사용자로 관리됩니다.
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole())), // 사용자의 권한 정보
+                attributes, // OAuth2 공급자로부터 받은 원본 속성
+                userNameAttributeName // 사용자 이름(ID) 속성 키 ("sub")
+        );
+
+        /* 참고: 만약 UserDetails 인터페이스까지 구현한 커스텀 Principal 객체를 사용하고 싶다면,
+           PrincipalDetails 클래스를 만들고 아래와 같이 반환할 수 있습니다.
+           return new PrincipalDetails(user, attributes);
+           PrincipalDetails 클래스는 UserDetails와 OAuth2User 인터페이스를 구현해야 합니다.
+        */
+    }
+
+    /**
+     * OAuth2 속성 정보를 기반으로 사용자를 찾거나 새로 생성하여 저장(또는 업데이트)합니다.
+     *
+     * @param attributes OAuth2 사용자 속성 DTO
+     * @return 저장되거나 업데이트된 User 엔티티 객체
+     */
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        // googleId로 사용자 조회
+        Optional<User> userOptional = userDAO.findByGoogleId(attributes.getGoogleId());
+        User user;
+
+        if (userOptional.isPresent()) {
+            // 기존 사용자: 이름이나 이메일이 변경되었을 수 있으므로 업데이트 시도
+            user = userOptional.get();
+            log.debug("Existing user found: userId={}", user.getUserId());
+            // User 엔티티에 updateOAuthInfo 메소드가 있다고 가정 (닉네임, 이메일 업데이트)
+            // 필요에 따라 업데이트 로직을 상세화할 수 있습니다.
+            user.updateOAuthInfo(attributes.getNickname(), attributes.getEmail(), attributes.getPicture());
+            userDAO.update(user); // DB 업데이트 실행
+            log.debug("Existing user updated.");
+        } else {
+            // 신규 사용자: OAuthAttributes DTO를 User 엔티티로 변환하여 저장
+            user = attributes.toEntity(); // User 엔티티 생성 (Role은 기본 USER)
+            log.debug("New user detected. Attempting to save...");
+            // TODO: 닉네임 중복 처리 로직 필요 시 여기에 추가
+            // 예: String uniqueNickname = generateUniqueNickname(user.getNickname()); user.updateNickname(uniqueNickname);
+            userDAO.save(user); // DB 저장 실행 (@Options에 의해 user 객체에 userId가 설정됨)
+            log.debug("New user saved with userId={}", user.getUserId());
+            // @Options가 잘 동작한다면 아래 재조회는 불필요. 만약을 위해 로그 확인.
+            // user = userDAO.findByGoogleId(attributes.getGoogleId())
+            //               .orElseThrow(() -> new OAuth2AuthenticationException("Failed to fetch user after save."));
+        }
+        return user;
+    }
+
+    // TODO: 필요시 닉네임 중복 처리 및 유니크 닉네임 생성 로직 구현
+    // private String generateUniqueNickname(String baseNickname) { ... }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAccessDeniedHandler.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,55 @@
+package com.ssafy.happymeal.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 필요한 접근 권한이 없을 때 403 Forbidden 에러를 반환하는 컴포넌트.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper; // JSON 응답 생성을 위해 주입
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("Responding with forbidden error. Message - {}", accessDeniedException.getMessage());
+
+        // 응답 상태 코드 설정 (403 Forbidden)
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        // 응답 컨텐츠 타입 설정 (JSON)
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // 문자 인코딩 설정 (UTF-8)
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        // JSON 응답 본문 생성
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("error", "Forbidden");
+        errorDetails.put("message", "접근 권한이 없습니다: " + accessDeniedException.getMessage());
+        // errorDetails.put("timestamp", System.currentTimeMillis());
+        // errorDetails.put("path", request.getRequestURI());
+
+        // ObjectMapper를 사용하여 Map을 JSON 문자열로 변환 후 응답 스트림에 쓰기
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(errorDetails));
+        } catch (IOException e) {
+            log.error("Error writing JSON error response", e);
+            throw e;
+        }
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,57 @@
+package com.ssafy.happymeal.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 유효한 자격증명(인증 토큰 등)을 제공하지 않고 접근하려 할 때
+ * 401 Unauthorized 에러를 반환하는 컴포넌트.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper; // JSON 응답 생성을 위해 주입
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("Responding with unauthorized error. Message - {}", authException.getMessage());
+
+        // 응답 상태 코드 설정 (401 Unauthorized)
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // 응답 컨텐츠 타입 설정 (JSON)
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // 문자 인코딩 설정 (UTF-8)
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        // JSON 응답 본문 생성
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("error", "Unauthorized");
+        errorDetails.put("message", "인증이 필요합니다: " + authException.getMessage());
+        // 필요시 추가 정보 포함 가능 (예: timestamp, path)
+        // errorDetails.put("timestamp", System.currentTimeMillis());
+        // errorDetails.put("path", request.getRequestURI());
+
+        // ObjectMapper를 사용하여 Map을 JSON 문자열로 변환 후 응답 스트림에 쓰기
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(errorDetails));
+        } catch (IOException e) {
+            log.error("Error writing JSON error response", e);
+            throw e;
+        }
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.ssafy.happymeal.security.jwt; // JWT 관련 패키지 경로
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils; // StringUtils 사용
+import org.springframework.web.filter.OncePerRequestFilter; // OncePerRequestFilter 상속
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * 클라이언트 요청 시마다 JWT의 유효성을 검증하고,
+ * 유효하다면 SecurityContext에 인증(Authentication) 객체를 저장하는 필터.
+ * SecurityConfig에 등록되어 특정 필터(예: UsernamePasswordAuthenticationFilter) 전에 실행됩니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter { // 요청당 한 번만 실행 보장
+
+    public static final String AUTHORIZATION_HEADER = "Authorization"; // 헤더 이름 상수
+    public static final String BEARER_PREFIX = "Bearer ";        // Bearer 타입 접두사 상수
+
+    private final JwtTokenProvider jwtTokenProvider; // JWT 처리 유틸리티 주입
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1. Request Header에서 토큰 추출
+        String jwt = resolveToken(request);
+        String requestURI = request.getRequestURI(); // 현재 요청 URI 로깅용
+
+        // 2. 토큰 유효성 검증
+        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+            // 3. 토큰이 유효할 경우 토큰에서 Authentication 객체 가져오기
+            Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+            // 4. SecurityContext에 Authentication 객체 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Authentication information saved in SecurityContext for user: {}, uri: {}", authentication.getName(), requestURI);
+        } else {
+            log.debug("No valid JWT found, uri: {}", requestURI);
+        }
+
+        // 5. 다음 필터로 제어 넘기기
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * HttpServletRequest의 헤더에서 'Authorization' 값을 추출하고,
+     * 'Bearer ' 접두사를 제거하여 순수 토큰 문자열을 반환합니다.
+     *
+     * @param request HttpServletRequest 객체
+     * @return 추출된 토큰 문자열 (없거나 형식이 맞지 않으면 null)
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length()); // "Bearer " 다음의 문자열 반환
+        }
+        return null;
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtTokenProvider.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,170 @@
+package com.ssafy.happymeal.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+// import javax.annotation.PostConstruct; // @PostConstruct 사용 안 하므로 주석 처리 또는 삭제
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+
+    private final String secret;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    private final Key key; // Key 객체를 final로 선언
+
+    /**
+     * 생성자를 통해 application.properties의 설정값을 주입받고,
+     * 주입받은 secret 값을 사용하여 JWT 서명에 사용할 Key 객체를 즉시 생성합니다.
+     *
+     * @param secret                           JWT 비밀 키 (Base64 인코딩된 값)
+     * @param accessTokenValidityInMilliseconds Access Token 유효 시간 (ms)
+     * @param refreshTokenValidityInMilliseconds Refresh Token 유효 시간 (ms)
+     */
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity-in-milliseconds}") long accessTokenValidityInMilliseconds,
+            @Value("${jwt.refresh-token-validity-in-milliseconds}") long refreshTokenValidityInMilliseconds) {
+
+        this.secret = secret; // 생성자 파라미터로 받은 secret 값 저장
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds;
+
+        // === 생성자 내에서 Key 객체 초기화 ===
+        byte[] keyBytes = Decoders.BASE64.decode(secret); // Base64 디코딩
+        this.key = Keys.hmacShaKeyFor(keyBytes);          // HMAC SHA 알고리즘 Key 생성 및 final 필드에 할당
+        log.info("JWT Key initialized successfully within constructor.");
+        // ==================================
+    }
+
+    /* @PostConstruct 메소드는 더 이상 필요 없음
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        log.info("JWT Key initialized successfully.");
+    }
+    */
+
+    /**
+     * 인증 정보를 기반으로 Access Token을 생성합니다.
+     * (이하 메소드들은 이전과 동일)
+     */
+    public String generateAccessToken(Long userId, String role) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim(AUTHORITIES_KEY, role)
+                .setIssuedAt(new Date(now))
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    /**
+     * 사용자 ID를 기반으로 Refresh Token을 생성합니다.
+     */
+    public String generateRefreshToken(Long userId) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.refreshTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(new Date(now))
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    /**
+     * Access Token을 복호화하여 인증(Authentication) 객체를 생성합니다.
+     */
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    /**
+     * 토큰의 유효성을 검증합니다.
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SignatureException e) {
+            log.error("Invalid JWT signature", e);
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token", e);
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token", e);
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token", e);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 클레임(Payload) 정보를 추출합니다.
+     */
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 ID (Subject)를 추출합니다.
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 토큰에서 사용자 역할(Role)을 추출합니다.
+     */
+    public String getRoleFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return (String) claims.get(AUTHORITIES_KEY);
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/OAuth2LoginSuccessHandler.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,104 @@
+package com.ssafy.happymeal.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.happymeal.domain.user.dao.UserDAO;
+import com.ssafy.happymeal.domain.user.entity.User;
+import com.ssafy.happymeal.security.jwt.JwtTokenProvider;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User; // DefaultOAuth2User 사용
+import org.springframework.security.oauth2.core.user.OAuth2User; // OAuth2User 임포트
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional; // DB 조회를 위해 추가
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+// @Transactional // 핸들러 자체보다는 DAO 호출 시 트랜잭션이 적용되므로 필수 아님 (필요시 추가)
+
+// AccessToken 생성
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+    private final UserDAO userDAO; // DB 조회를 위해 userDAO 주입
+
+    @Override
+    @Transactional(readOnly = true) // DB 조회가 있으므로 읽기 전용 트랜잭션 권장
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login successful! Attempting to issue JWT.");
+
+        // 1. 인증된 사용자 정보 가져오기 (DefaultOAuth2User 타입)
+        // CustomOAuth2UserService에서 반환한 DefaultOAuth2User 객체가 principal로 들어옴
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // 2. Google ID (Subject) 추출
+        // DefaultOAuth2User의 getName()은 생성 시 사용된 userNameAttributeName("sub")에 해당하는 값을 반환
+        String googleId = oAuth2User.getName();
+        log.debug("Extracted googleId (sub) from principal: {}", googleId);
+
+        // 3. Google ID를 사용하여 DB에서 사용자 정보 다시 조회
+        Optional<User> userOptional = userDAO.findByGoogleId(googleId);
+
+        if (userOptional.isEmpty()) {
+            // CustomOAuth2UserService에서 사용자를 저장했어야 하므로, 여기서 찾을 수 없다면 심각한 오류 상황
+            log.error("FATAL: Cannot find user in DB after successful OAuth2 login. googleId: {}", googleId);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.getWriter().write("{\"error\": \"User not found after login.\"}");
+            return; // 처리 중단
+        }
+
+        // 4. 조회된 User 객체에서 userId와 role 추출
+        User user = userOptional.get();
+        Long userId = user.getUserId();
+        String role = user.getRole(); // User 엔티티의 String 타입 role 필드
+        log.info("User found in DB: userId={}, role={}", userId, role);
+
+        // 5. JwtTokenProvider를 사용하여 Access Token 및 Refresh Token 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(userId, role);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+        log.debug("Generated Access Token: {}", accessToken);
+        log.debug("Generated Refresh Token: {}", refreshToken);
+
+        // 6. 응답 설정 및 본문에 토큰 담아 전송 (이전과 동일)
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        try {
+            TokenResponseDto tokenResponse = new TokenResponseDto(accessToken, refreshToken);
+            response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+            log.info("Successfully sent tokens to client for userId: {}", userId);
+        } catch (IOException e) {
+            log.error("Error writing token response to output stream", e);
+            throw e;
+        }
+    }
+
+    // 간단한 토큰 응답 DTO
+    @Getter
+    @Setter
+    private static class TokenResponseDto {
+        private String accessToken;
+        private String refreshToken;
+
+        public TokenResponseDto(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
+}

--- a/Backend/src/main/resources/application.properties
+++ b/Backend/src/main/resources/application.properties
@@ -3,9 +3,22 @@ spring.application.name=HappyMeal
 ##MySQL
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 ##database
-spring.datasource.url=jdbc:mysql://localhost:3306/nyamnyam?characterEncoding=utf8
-spring.datasource.username: root
-spring.datasource.password: ssafy
+spring.datasource.url=${DB_url}
+spring.datasource.username=${DB_username}
+spring.datasource.password=${DB_password}
 
 #mappers
 #mybatis.mapper-locations=classpath*:mappers/*.xml : @Mapper ????? ?? ???
+mybatis.configuration.map-underscore-to-camel-case=true
+
+#Google OAuth
+spring.security.oauth2.client.registration.google.client-id=${google_client_id}
+spring.security.oauth2.client.registration.google.client-secret=${google_client_secret}
+spring.security.oauth2.client.registration.google.scope=email,profile
+
+#JWT
+jwt.secret=${jwt_secret}
+# Access Token ?? ?? (ms ??) - ?: 30?
+jwt.access-token-validity-in-milliseconds=1800000
+# Refresh Token ?? ?? (ms ??) - ?: 7?
+jwt.refresh-token-validity-in-milliseconds=604800000


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #5  -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

-OAuth2.0을 이용한 구글 로그인 구현
-서버 자체 jwt token 설정을 위한 핸들러와 필터 구현

## 스크린샷

![스크린샷 2025-05-02 오후 2 50 28](https://github.com/user-attachments/assets/b40b6678-26f6-4bd3-a1fd-221913f7b3ca)

## 공유사항 to 리뷰어

로그인 성공 후 JWT 발급 시 userId 사용을 위한 추가 조회 발생
추후 아래와 같은 방식으로 개선 예정

📌 DefaultOAuth2User의 Attributes 맵 활용 (약간의 트릭):

CustomOAuth2UserService의 loadUser 메소드 마지막에서 DefaultOAuth2User를 생성할 때, attributes 맵을 복사한 뒤 커스텀 속성(예: "internalUserId", "internalRole")으로 우리 시스템의 userId와 role을 추가해서 넘겨줍니다.
OAuth2LoginSuccessHandler에서는 authentication.getPrincipal().getAttributes()를 통해 이 맵을 얻고, 추가했던 커스텀 속성("internalUserId", "internalRole")을 키로 사용하여 값을 꺼냅니다. (타입 캐스팅 필요)

단점: attributes 맵은 원래 OAuth 공급자가 제공한 속성을 담기 위한 것인데, 여기에 내부 시스템 정보를 넣는 것은 맵의 본래 목적과 약간 다릅니다. 값을 꺼낼 때 키 이름을 문자열로 사용해야 하고 타입 캐스팅이 필요하여 타입-안전성이 떨어집니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).