### PR TITLE
feat: mealLog 식단 기록 저장

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                                 "/api/food-requests", // 음식 요청 (POST)
                                 "/api/board" // 게시글 작성(POST), 수정(PUT), 삭제(DELETE) - 세부 검증은 컨트롤러/서비스에서
                         ).hasAnyRole("USER", "ADMIN") // USER 또는 ADMIN 역할 필요
+//                        ).hasAuthority("USER") // JWT에 "USER"라고 넣었을 때만 일치
 
                         // 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
@@ -1,4 +1,34 @@
 package com.ssafy.happymeal.domain.meallog.controller;
 
+import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+import com.ssafy.happymeal.domain.meallog.service.MealLogService;
+import com.ssafy.happymeal.domain.meallog.service.MealLogServiceIml;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/meallogs")
+@RequiredArgsConstructor
 public class MealLogController {
+
+    private final MealLogServiceIml mealLogService;
+
+    @PostMapping
+    public ResponseEntity<?> addMealLog(@RequestBody MealLogDto mealLogDto, @AuthenticationPrincipal UserDetails userDetails) {
+        // UserDetails : 어떤 사용자가 식단을 등록하는지 알아야 MealLog.user_id에 넣을 수 있기 때문에 필요함
+        Long userId = Long.parseLong(userDetails.getUsername());
+        mealLogService.addMealLog(userId, mealLogDto);
+        log.info("식단 기록 요청 : " +userId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
@@ -1,4 +1,14 @@
 package com.ssafy.happymeal.domain.meallog.dao;
 
+import com.ssafy.happymeal.domain.meallog.entity.MealLog;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
 public interface MealLogDAO {
+
+    @Insert("insert into MealLog(user_id, food_id, meal_date, meal_type, quantity, img_url, create_at)" +
+            " values(#{userId}, #{foodId}, #{mealDate}, #{mealType}, #{quantity}, #{imgUrl}, NOW())")
+    void insertMealLog(MealLog mealLog);
+
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogDto.java
@@ -1,4 +1,35 @@
 package com.ssafy.happymeal.domain.meallog.dto;
 
+import com.ssafy.happymeal.domain.meallog.entity.MealLog;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
 public class MealLogDto {
+    private String mealDate; // 타입 : LocalDate
+    private String mealType;
+    private Long foodId;
+    private BigDecimal quantity;
+    private String imgUrl;
+
+    /* 사용자 식단 기록 요청 -> DB 저장용 객체 변환 */
+    // 사용자가 직접 넣지 않는 값은 toEntity 파라미터로 받음
+//    public MealLog toEntity(Long userId) {
+//        MealLog mealLog = new MealLog();
+//
+//        mealLog.setUserId(userId);
+//        mealLog.setFoodId(this.foodId);
+//        mealLog.setMealDate(LocalDate.parse(this.mealDate));
+//        mealLog.setMealType(this.mealType.toUpperCase());
+//        mealLog.setQuantity(this.quantity);
+//        mealLog.setImgUrl(this.imgUrl);
+//
+//        return mealLog;
+//    }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/entity/MealLog.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/entity/MealLog.java
@@ -1,4 +1,26 @@
 package com.ssafy.happymeal.domain.meallog.entity;
 
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MealLog {
+
+    private Long logId;
+    private Long userId; // FK - User 테이블 참조
+    private Long foodId; // FK - Food 테이블 참조
+    private LocalDate mealDate;
+    private String mealType;
+    private BigDecimal quantity;
+    private String imgUrl;
+    private Timestamp createAt;
+
+
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
@@ -1,4 +1,8 @@
 package com.ssafy.happymeal.domain.meallog.service;
 
+import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+
 public interface MealLogService {
+
+    void addMealLog(Long userId, MealLogDto mealLogDto);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
@@ -1,4 +1,33 @@
 package com.ssafy.happymeal.domain.meallog.service;
 
-public class MealLogServiceIml {
+import com.ssafy.happymeal.domain.meallog.dao.MealLogDAO;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+import com.ssafy.happymeal.domain.meallog.entity.MealLog;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MealLogServiceIml implements MealLogService{
+
+    private final MealLogDAO mealLogDAO;
+
+    @Override
+    public void addMealLog(Long userId, MealLogDto mealLogDto) {
+        MealLog mealLog = new MealLog();
+
+        mealLog.setUserId(userId);
+        mealLog.setFoodId(mealLogDto.getFoodId());
+        mealLog.setMealDate(LocalDate.parse(mealLogDto.getMealDate()));
+        mealLog.setMealType(mealLogDto.getMealType());
+        mealLog.setQuantity(mealLogDto.getQuantity());
+        mealLog.setImgUrl(mealLogDto.getImgUrl());
+
+        mealLogDAO.insertMealLog(mealLog);
+        log.info("✅ 최종 저장할 MealLog 객체: {}", mealLog);
+    }
 }


### PR DESCRIPTION
## 개요

user_id를 프론트에서 다시 넘겨주는 작업이 불필요 하다고 생각해, jwt에 저장된 사용자 정보를 꺼내 넘겨주는 방식을 적용
컨트롤러에서 @AuthenticationPrincipal을 이용함

<!---- Resolves: #12 -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

✏️ mealLog 식단 기록 post 요청 처리

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

- 1️⃣ SecurityConfig에서 설정한 권한과 실제 인증 객체 권한 일치를 위해 토큰 생성시(JwtTokenProvider.generateAccessToken())
"ROLE_" + role 을 강제적으로 지정
- 2️⃣ 요청 확인을 위해 jwt 토큰을 로그에 남김 (배포 환경에서는 콘솔에 토큰을 출력하는 건 **보안상 위험**하므로 반드시 제거! 🔒)

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).