### PR TITLE
feat : 식단기록 조회 및 삭제 기능 추가

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
@@ -1,19 +1,20 @@
 package com.ssafy.happymeal.domain.meallog.controller;
 
 import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogResponseDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogStatsDto;
 import com.ssafy.happymeal.domain.meallog.service.MealLogService;
-import com.ssafy.happymeal.domain.meallog.service.MealLogServiceIml;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -21,14 +22,54 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MealLogController {
 
-    private final MealLogServiceIml mealLogService;
+    private final MealLogService mealLogService;
 
+    // 식단 기록 추가
     @PostMapping
     public ResponseEntity<?> addMealLog(@RequestBody MealLogDto mealLogDto, @AuthenticationPrincipal UserDetails userDetails) {
         // UserDetails : 어떤 사용자가 식단을 등록하는지 알아야 MealLog.user_id에 넣을 수 있기 때문에 필요함
         Long userId = Long.parseLong(userDetails.getUsername());
         mealLogService.addMealLog(userId, mealLogDto);
-        log.info("식단 기록 요청 : " +userId);
+        log.info("식단 기록 요청 : userId={}", userId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 전체 식단 기록 조회
+    @GetMapping
+    public ResponseEntity<List<MealLogResponseDto>> getAllMealLogs(@AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        List<MealLogResponseDto> logs = mealLogService.getAllMealLogs(userId);
+        log.info("식단 조회 요청 아이디 : userId={}", userId);
+        return ResponseEntity.ok(logs);
+    }
+
+    // 특정 날짜 식단 기록 조회
+    @GetMapping(params = "date")
+    public ResponseEntity<List<MealLogResponseDto>> getMealLogsByMealDate(@RequestParam("date") String date, @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        LocalDate mealDate = LocalDate.parse(date); // 프론트엔드에서 날짜 포맷은 반드시 YYYY-MM-DD 형식으로 맞춰 보내야함
+        List<MealLogResponseDto> logs = mealLogService.findByUserAndDate(userId, mealDate);
+        log.info("요청 조회 날짜 : mealDate={}", mealDate);
+        return ResponseEntity.ok(logs);
+    }
+
+    // 특정 날짜 식단 통계 조회
+    @GetMapping("/stats")
+    public ResponseEntity<MealLogStatsDto> getMealLogStatsByMealDate(@RequestParam("date") String date, @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        LocalDate mealDate = LocalDate.parse(date);
+        MealLogStatsDto stats = mealLogService.getDailyMealStats(userId, mealDate);
+        log.info("통계 요청 날짜 : mealDate={}", mealDate);
+        return ResponseEntity.ok(stats);
+    }
+
+    // 식단 기록 삭제
+    @DeleteMapping("/{logId}")
+    public ResponseEntity<?> deleteMealLog(@PathVariable Long logId, @AuthenticationPrincipal UserDetails userDetails) throws NotFoundException {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        log.info("식단 삭제 요청 : userId={}, logId={}", userId, logId);
+        mealLogService.deleteMealLog(userId, logId);
+        log.info("식단 삭제 완료 : logId={}", logId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
@@ -1,14 +1,51 @@
 package com.ssafy.happymeal.domain.meallog.dao;
 
+import com.ssafy.happymeal.domain.meallog.dto.MealLogResponseDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogStatsDto;
 import com.ssafy.happymeal.domain.meallog.entity.MealLog;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface MealLogDAO {
 
-    @Insert("insert into MealLog(user_id, food_id, meal_date, meal_type, quantity, img_url, create_at)" +
-            " values(#{userId}, #{foodId}, #{mealDate}, #{mealType}, #{quantity}, #{imgUrl}, NOW())")
+    @Select("Select * " +
+            "From MealLog " +
+            "Where log_id=#{logId}"
+    )
+    Optional<MealLog> findById(Long logId);
+
+    @Insert("Insert into MealLog(user_id, food_id, meal_date, meal_type, quantity, img_url, create_at)" +
+            " Values(#{userId}, #{foodId}, #{mealDate}, #{mealType}, #{quantity}, #{imgUrl}, NOW())")
     void insertMealLog(MealLog mealLog);
+
+    @Select("Select m.log_id AS logId, f.name AS foodName, img_url AS imgUrl, m.meal_type AS mealType, f.calories " + // SELECT 컬럼과 DTO 필드가 정확히 일치해야 하기 때문에 Alias를 사용
+            "From MealLog m " +
+            "Join Food f ON m.food_id = f.food_id " +
+            "Where m.user_id = #{userId}")
+    List<MealLogResponseDto> getAllMealLogs(Long userId);
+
+    @Select("Select m.log_id AS logId, f.name AS foodName, img_url AS imgUrl, m.meal_type AS mealType, f.calories " + // SELECT 컬럼과 DTO 필드가 정확히 일치해야 하기 때문에 Alias를 사용
+            "From MealLog m " +
+            "Join Food f ON m.food_id = f.food_id " +
+            "Where m.user_id = #{userId} AND m.meal_date = #{mealDate}")
+    // List<MealLogDto> findMealLogsByUserAndDate(Long userId, LocalDate mealDate);
+    // MyBatis는 순서 기반 바인딩을 하다가 혼동할 수 있음 : @Param 사용 (⭕️필수는 아님)
+    List<MealLogResponseDto> findByUserAndDate(@Param("userId") Long userId, @Param("mealDate") LocalDate mealDate);
+
+    @Delete("Delete From MealLog " +
+            "Where user_id = #{userId} AND log_id = #{logId}")
+    void deleteMealLog(Long userId, Long logId);
+
+
+    @Select("Select sum(f.calories) AS totalCalories, sum(f.carbs) AS totalCarbs, " +
+            "sum(f.sugar) AS totalSugar, sum(f.protein) AS totalProtein, sum(f.fat) AS totalFat " +
+            "From MealLog m " +
+            "Join Food f ON m.food_id = f.food_id " +
+            "Where m.user_id=#{userId} AND m.meal_date=#{mealDate}")
+    MealLogStatsDto getDailyMealStats(@Param("userId") Long userId, @Param("mealDate") LocalDate mealDate);
 
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
+// 식단 기록 저장용 DTO
 public class MealLogDto {
     private String mealDate; // 타입 : LocalDate
     private String mealType;

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogResponseDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogResponseDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.happymeal.domain.meallog.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+// 특정 날짜 식단 기록 조회용 DTO
+public class MealLogResponseDto {
+    private Long logId;
+    private String foodName; // 조회 시 음식 반환을 위해 사용
+    private String imgUrl;
+    private String mealType;
+    private BigDecimal calories;
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogStatsDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogStatsDto.java
@@ -1,0 +1,20 @@
+package com.ssafy.happymeal.domain.meallog.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+// 식단 통계 조회 DTO
+public class MealLogStatsDto {
+    private BigDecimal totalCalories;
+    private BigDecimal totalCarbs;
+    private BigDecimal totalSugar;
+    private BigDecimal totalProtein;
+    private BigDecimal totalFat;
+
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/entity/MealLog.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/entity/MealLog.java
@@ -21,6 +21,4 @@ public class MealLog {
     private BigDecimal quantity;
     private String imgUrl;
     private Timestamp createAt;
-
-
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
@@ -1,8 +1,22 @@
 package com.ssafy.happymeal.domain.meallog.service;
 
 import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogResponseDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogStatsDto;
+import org.apache.ibatis.javassist.NotFoundException;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface MealLogService {
 
     void addMealLog(Long userId, MealLogDto mealLogDto);
+
+    List<MealLogResponseDto> findByUserAndDate(Long userId, LocalDate mealDate);
+
+    void deleteMealLog(Long userId, Long logId) throws NotFoundException;
+
+    MealLogStatsDto getDailyMealStats(Long userId, LocalDate mealDate);
+
+    List<MealLogResponseDto> getAllMealLogs(Long userId);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
@@ -2,12 +2,18 @@ package com.ssafy.happymeal.domain.meallog.service;
 
 import com.ssafy.happymeal.domain.meallog.dao.MealLogDAO;
 import com.ssafy.happymeal.domain.meallog.dto.MealLogDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogResponseDto;
+import com.ssafy.happymeal.domain.meallog.dto.MealLogStatsDto;
 import com.ssafy.happymeal.domain.meallog.entity.MealLog;
+import com.ssafy.happymeal.domain.user.dao.UserDAO;
+import com.ssafy.happymeal.global.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -15,6 +21,7 @@ import java.time.LocalDate;
 public class MealLogServiceIml implements MealLogService{
 
     private final MealLogDAO mealLogDAO;
+    private final UserDAO userDAO;
 
     @Override
     public void addMealLog(Long userId, MealLogDto mealLogDto) {
@@ -28,6 +35,33 @@ public class MealLogServiceIml implements MealLogService{
         mealLog.setImgUrl(mealLogDto.getImgUrl());
 
         mealLogDAO.insertMealLog(mealLog);
-        log.info("✅ 최종 저장할 MealLog 객체: {}", mealLog);
+    }
+
+    @Override
+    public List<MealLogResponseDto> findByUserAndDate(Long userId, LocalDate mealDate) {
+        return mealLogDAO.findByUserAndDate(userId, mealDate);
+    }
+
+    @Override
+    public void deleteMealLog(Long userId, Long logId) throws NotFoundException {
+        // 일치하는 식단 기록이 없을 경우
+        MealLog mealLog = mealLogDAO.findById(logId)
+                .orElseThrow(() -> new NotFoundException("식단 기록이 존재하지 않습니다."));
+
+        // 일치하는 사용자가 아닌 경우
+        if(!mealLog.getUserId().equals(userId)) {
+            throw new ForbiddenException("본인의 기록만 삭제할 수 있습니다.");
+        }
+        mealLogDAO.deleteMealLog(userId, logId);
+    }
+
+    @Override
+    public MealLogStatsDto getDailyMealStats(Long userId, LocalDate mealDate) {
+        return mealLogDAO.getDailyMealStats(userId, mealDate);
+    }
+
+    @Override
+    public List<MealLogResponseDto> getAllMealLogs(Long userId) {
+        return mealLogDAO.getAllMealLogs(userId);
     }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/dao/UserDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/dao/UserDAO.java
@@ -19,7 +19,7 @@ public interface UserDAO {
             "from User " +
             "where user_id=#{userId}"
     )
-    Optional<User> findById(String userId);
+    Optional<User> findById(Long userId);
 
     // User 정보 저장
     @Insert("insert into User(google_id, email, nickname, role, profile_image_url, create_at)"

--- a/Backend/src/main/java/com/ssafy/happymeal/global/exception/ForbiddenException.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/global/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.ssafy.happymeal.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/Backend/src/main/resources/application.properties
+++ b/Backend/src/main/resources/application.properties
@@ -19,6 +19,6 @@ spring.security.oauth2.client.registration.google.scope=email,profile
 #JWT
 jwt.secret=${jwt_secret}
 # Access Token ?? ?? (ms ??) - ?: 30?
-jwt.access-token-validity-in-milliseconds=1800000
+jwt.access-token-validity-in-milliseconds=18000000
 # Refresh Token ?? ?? (ms ??) - ?: 7?
 jwt.refresh-token-validity-in-milliseconds=604800000


### PR DESCRIPTION
## 개요

식단 기록 조회 및 삭제 로직 구현

<!---- Resolves: #15 -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

1️⃣ 저장용 MealLogDto, 조회용 MealLogResponseDto, 통계용 MealLogStatsDto 를 생성
2️⃣ 식단 전체 조회와 특정 날짜에 대한 식단 조회 구현 - 특정 날짜에 대한 바디값 형식(String)을 mybatis에 지정한 형식인 LocalDate로  변경하는 작업 동반
3️⃣ 유저가 담은 식단 테이블과 food 테이블을 join해서 특정 날짜에 대한 식단 칼로리, 영양소 통계 반환
4️⃣ 유저가 삭제하고자 하는 식단이 존재하는지 검사 후, 조회 요청 유저와 식단 기록 유저가 일치하는지 서비스단에서 검사

## 공유사항 to 리뷰어

- 🕖 application.properties에서 토큰 유지 시간 18000000(ms) 늘림
- 📁 식단 **상세 조회** 기능 추가 예정

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).