### PR TITLE
update : 유저 닉네임 한글 인코딩 로직 추가

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/security/jwt/OAuth2LoginSuccessHandler.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/security/jwt/OAuth2LoginSuccessHandler.java
@@ -21,6 +21,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import lombok.*;
@@ -65,6 +66,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         User user = userOptional.get();
         Long userId = user.getUserId();
         String role = user.getRole();
+        // 닉네임을 UTF-8로 URL 인코딩합니다.
+        String encodedNickname = URLEncoder.encode(user.getNickname(), StandardCharsets.UTF_8.toString());
         log.info("User found in DB: userId={}, role={}", userId, role);
 
         String accessToken = jwtTokenProvider.generateAccessToken(userId, role);
@@ -78,7 +81,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .queryParam("userId", userId) // 선택: 사용자 ID도 전달
-                .queryParam("nickname", user.getNickname()) // 선택: 닉네임도 전달
+//                .queryParam("nickname", user.getNickname()) // 선택: 닉네임도 전달
+                .queryParam("nickname", encodedNickname) // 선택: 닉네임도 전달
                 .build().toUriString();
 
         // 2. 리디렉션 수행


### PR DESCRIPTION
## 개요

🚨 로그인 성공 후, 백엔드에서 프론트엔드로 리다이렉트하는 URL을 생성할 때, 쿼리 파라미터 중 nickname=한글 부분에서 '한글'라는 한글이 
URL 인코딩되지 않은 채로 Location 헤더에 포함.

Location 헤더에 들어가는 URL 값은 RFC 규격에 따라 특정 문자들(특히 ASCII 범위를 벗어나는 문자나 URL에서 특별한 의미를 가지는 문자)은 반드시 퍼센트 인코딩(Percent-encoding 또는 URL 인코딩)하도록 수정

<!---- Resolves: #64  -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

OAuth2LoginSuccessHandler에서 리다이렉트할 때 nickname을 URLEncoder.encode(nickname, StandardCharsets.UTF_8.toString())를 사용하여 nickname 값을 인코딩

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).