### PR TITLE
[BE] 음식 목록 페이지네이션 구현

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.ssafy.happymeal.domain.board.controller;
 
 import com.ssafy.happymeal.domain.board.dto.*;
 import com.ssafy.happymeal.domain.board.service.BoardService;
+import com.ssafy.happymeal.domain.commonDto.PageResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.Getter;
@@ -19,25 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
-// 가상의 PageResponse (페이징된 결과를 담는 클래스)
-@Getter
-@Setter
-class PageResponse<T> {
-    public List<T> content;
-    public int pageNumber;
-    public int pageSize;
-    public long totalElements;
-    public int totalPages;
 
-    public PageResponse(List<T> content, int pageNumber, int pageSize, long totalElements) {
-        this.content = content;
-        this.pageNumber = pageNumber;
-        this.pageSize = pageSize;
-        this.totalElements = totalElements;
-        this.totalPages = (int) Math.ceil((double) totalElements / pageSize); // 한 페이지에 몇개 보여줄지에 따라 전체 페이지 수 계산
-    }
-
-}
 
 @Slf4j
 @RestController

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/commonDto/PageResponse.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/commonDto/PageResponse.java
@@ -1,0 +1,25 @@
+package com.ssafy.happymeal.domain.commonDto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PageResponse<T> {
+    public List<T> content;
+    public int pageNumber;
+    public int pageSize;
+    public long totalElements;
+    public int totalPages;
+
+    public PageResponse(List<T> content, int pageNumber, int pageSize, long totalElements) {
+        this.content = content;
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = (int) Math.ceil((double) totalElements / pageSize); // 한 페이지에 몇개 보여줄지에 따라 전체 페이지 수 계산
+    }
+
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/dao/FoodDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/dao/FoodDAO.java
@@ -72,6 +72,51 @@ public interface FoodDAO {
     @Delete("DELETE FROM Food WHERE food_id = #{foodId}")
     int delete(@Param("foodId") Long foodId);
 
+    // 이름으로 검색 (페이징 및 정렬 추가)
+    @Select("<script>" +
+            "SELECT " + BASE_COLUMNS + " FROM Food " +
+            "<where>" +
+            "   <if test='params.name != null and params.name != \"\"'>" +
+            "       AND name LIKE CONCAT('%', #{params.name}, '%')" +
+            "   </if>" +
+            "</where>" +
+            "<if test='params.orderByClause != null and params.orderByClause != \"\"'>" +
+            "   ORDER BY ${params.orderByClause}" + // SQL Injection 주의: 서비스에서 안전하게 구성
+            "</if>" +
+            "<if test='(params.orderByClause == null or params.orderByClause == \"\")'>" +
+            "   ORDER BY name ASC" + // 기본 정렬
+            "</if>" +
+            " LIMIT #{params.limit} OFFSET #{params.offset}" +
+            "</script>")
+    List<Food> searchByNamePaginatedAndSorted(@Param("params") Map<String, Object> params);
+
+    @Select("<script>" +
+            "SELECT COUNT(*) FROM Food " +
+            "<where>" +
+            "   <if test='name != null and name != \"\"'>" +
+            "       AND name LIKE CONCAT('%', #{name}, '%')" +
+            "   </if>" +
+            "</where>" +
+            "</script>")
+    long countSearchByName(@Param("name") String name);
+
+
+    // 모든 음식 정보 조회 (페이징 및 정렬 추가)
+    @Select("<script>" +
+            "SELECT " + BASE_COLUMNS + " FROM Food" +
+            "<if test='params.orderByClause != null and params.orderByClause != \"\"'>" +
+            "   ORDER BY ${params.orderByClause}" + // SQL Injection 주의
+            "</if>" +
+            "<if test='(params.orderByClause == null or params.orderByClause == \"\")'>" +
+            "   ORDER BY name ASC" + // 기본 정렬
+            "</if>" +
+            " LIMIT #{params.limit} OFFSET #{params.offset}" +
+            "</script>")
+    List<Food> findAllPaginatedAndSorted(@Param("params") Map<String, Object> params);
+
+    @Select("SELECT COUNT(*) FROM Food")
+    long countAll();
+
     /**
      * 간결화된 추천 음식 조회 메소드 (영양소 수치 기반 필터링, 랜덤 3개)
      */

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/dto/FoodNameSearchCriteria.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/dto/FoodNameSearchCriteria.java
@@ -1,0 +1,17 @@
+package com.ssafy.happymeal.domain.food.dto; // 실제 DTO 패키지 경로
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FoodNameSearchCriteria extends FoodPagingSortCriteria {
+    private String name; // 검색할 음식 이름
+
+    public FoodNameSearchCriteria(String name, String sortBy, int page, int size) {
+        super(sortBy, page, size);
+        this.name = name;
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/dto/FoodPagingSortCriteria.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/dto/FoodPagingSortCriteria.java
@@ -1,0 +1,18 @@
+package com.ssafy.happymeal.domain.food.dto; // 실제 DTO 패키지 경로
+
+  import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FoodPagingSortCriteria {
+    private String sortBy; // 정렬 기준 필드명 (예: "name", "calories")
+    private int page;      // 요청 페이지 번호 (0부터 시작)
+    private int size;      // 페이지 당 아이템 수
+    // 필요시 정렬 방향 (ASC, DESC) 필드 추가 가능
+    // private String sortDirection;
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodService.java
@@ -1,23 +1,26 @@
 package com.ssafy.happymeal.domain.food.service;
 
+import com.ssafy.happymeal.domain.food.dto.FoodNameSearchCriteria;
+import com.ssafy.happymeal.domain.food.dto.FoodPagingSortCriteria;
 import com.ssafy.happymeal.domain.food.entity.Food; // Food DTO로 사용
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface FoodService {
 
-    /**
-     * 음식 정보 검색 (이름 기반)
-     * @param name 검색할 음식 이름 (부분 일치)
-     * @return 검색된 음식 정보 DTO 리스트
-     */
-    List<Food> searchFoodsByName(String name);
-
-    /**
-     * 모든 음식 정보 조회
-     * @return 모든 음식 정보 DTO 리스트
-     */
-    List<Food> getAllFoods();
+//    /**
+//     * 음식 정보 검색 (이름 기반)
+//     * @param name 검색할 음식 이름 (부분 일치)
+//     * @return 검색된 음식 정보 DTO 리스트
+//     */
+//    List<Food> searchFoodsByName(String name);
+//
+//    /**
+//     * 모든 음식 정보 조회
+//     * @return 모든 음식 정보 DTO 리스트
+//     */
+//    List<Food> getAllFoods();
 
     /**
      * 특정 ID의 음식 정보 조회
@@ -49,6 +52,13 @@ public interface FoodService {
      * @throws jakarta.persistence.EntityNotFoundException 해당 ID의 음식이 없을 경우 (삭제 시도 전에 확인)
      */
     void deleteFood(Long foodId);
+
+    // 이름으로 음식 검색 (페이징 및 정렬 추가)
+    Page<Food> searchFoodsByName(FoodNameSearchCriteria criteria);
+
+    // 모든 음식 조회 (페이징 및 정렬 추가)
+    Page<Food> getAllFoods(FoodPagingSortCriteria criteria);
+
 
     List<Food> getRecommendedFoods(String categoryName); // 반환 타입 변경
 


### PR DESCRIPTION
## 개요
<!---- Resolves: #66  -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

Food API 목록 조회 기능 페이징 및 정렬 기능 추가
GET /api/foods (전체 음식 목록 조회) API에 페이징 및 정렬 기능 적용.
GET /api/foods/search (음식 이름 검색) API에 페이징 및 정렬 기능 적용.

응답 형식 변경:
목록 조회 API의 응답을 PageResponse<Food> 커스텀 DTO로 변경하여 페이징 정보(content, pageNumber, pageSize, totalElements, totalPages)를 일관되게 제공하도록 수정. (기존 BoardController의 PageResponse와 동일한 구조 사용)

## 스크린샷

- 전체 조회결과
![image](https://github.com/user-attachments/assets/1a8cbe15-f478-4545-861c-dcd139696364)

- "닭"을 검색한 결과
![image](https://github.com/user-attachments/assets/624c10e0-c317-45e4-9250-cfd06fbd356f)

- commonDto 패키지 추가 및 PageResponse.java 위치 이동.
![image](https://github.com/user-attachments/assets/72de5bcc-64cb-4e1d-bbf6-6fe7ac0c6a0b)






## 공유사항 to 리뷰어

페이징 응답 구조 (PageResponse<T>):

BoardController와 일관성을 유지하기 위해 커스텀 PageResponse<T> DTO를 도입하여 페이징 관련 정보를(content, pageNumber, pageSize, totalElements, totalPages) 명확하게 전달

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).