### PR TITLE
[BE] 7일치 식단 통계 조회 요청

### DIFF
--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -9,6 +9,13 @@
     <value-preview-text-wrapping value="false" />
     <value-preview-pinned value="false" />
   </component>
+  <component name="DBNavigator.Project.DatabaseAssistantManager">
+    <assistants>
+      <assistant-state connection-id="c96cc15b-6c3e-4ff9-9c6a-513e92eb02dd" default-profile-name="" selected-profile-name="" selected-model-name="" assistant-type="GENERIC" selected-action="SHOW_SQL" availability="UNAVAILABLE" acknowledgement="NONE">
+        <messages />
+      </assistant-state>
+    </assistants>
+  </component>
   <component name="DBNavigator.Project.DatabaseBrowserManager">
     <autoscroll-to-editor value="false" />
     <autoscroll-from-editor value="true" />
@@ -23,6 +30,10 @@
   </component>
   <component name="DBNavigator.Project.ExecutionManager">
     <retain-sticky-names value="false" />
+  </component>
+  <component name="DBNavigator.Project.ObjectQuickFilterManager">
+    <last-used-operator value="EQUAL" />
+    <filters />
   </component>
   <component name="DBNavigator.Project.Settings">
     <connections />
@@ -57,9 +68,15 @@
           <object-type name="TYPE" enabled="true" />
           <object-type name="TYPE_ATTRIBUTE" enabled="true" />
           <object-type name="ARGUMENT" enabled="true" />
+          <object-type name="JAVA_CLASS" enabled="true" />
+          <object-type name="JAVA_INNER_CLASS" enabled="true" />
+          <object-type name="JAVA_FIELD" enabled="true" />
+          <object-type name="JAVA_METHOD" enabled="true" />
           <object-type name="DIMENSION" enabled="true" />
           <object-type name="CLUSTER" enabled="true" />
           <object-type name="DBLINK" enabled="true" />
+          <object-type name="CREDENTIAL" enabled="true" />
+          <object-type name="AI_PROFILE" enabled="true" />
         </object-type-filter>
       </filters>
       <sorting>
@@ -96,9 +113,15 @@
           <object-type name="FUNCTION" enabled="true" />
           <object-type name="PACKAGE" enabled="true" />
           <object-type name="TYPE" enabled="true" />
+          <object-type name="JAVA CLASS" enabled="true" />
+          <object-type name="INNER CLASS" enabled="true" />
+          <object-type name="JAVA FIELD" enabled="true" />
+          <object-type name="JAVA METHOD" enabled="true" />
+          <object-type name="JAVA PARAMETER" enabled="true" />
           <object-type name="DIMENSION" enabled="false" />
           <object-type name="CLUSTER" enabled="false" />
           <object-type name="DBLINK" enabled="true" />
+          <object-type name="CREDENTIAL" enabled="false" />
         </lookup-objects>
         <force-database-load value="false" />
         <prompt-connection-selection value="true" />
@@ -388,6 +411,7 @@
         <mapping file-type-id="TYPE" extensions="tpe" />
         <mapping file-type-id="TYPE_SPEC" extensions="tps" />
         <mapping file-type-id="TYPE_BODY" extensions="tpb" />
+        <mapping file-type-id="JAVA_SOURCE" extensions="sql" />
       </extensions>
       <general>
         <lookup-ddl-files value="true" />
@@ -397,6 +421,11 @@
         <make-scripts-rerunnable value="true" />
       </general>
     </ddl-file-settings>
+    <assistant-settings>
+      <credential-settings>
+        <credentials />
+      </credential-settings>
+    </assistant-settings>
     <general-settings>
       <regional-settings>
         <date-format value="MEDIUM" />

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/controller/MealLogController.java
@@ -63,6 +63,16 @@ public class MealLogController {
         return ResponseEntity.ok(stats);
     }
 
+    // 주간 식단 통계 조회
+    @GetMapping("/stats/weekly")
+    public ResponseEntity<List<MealLogStatsDto>> getWeeklyMealLogStats(@RequestParam("date") String date, @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        LocalDate endDate = LocalDate.parse(date);
+        List<MealLogStatsDto> weeklyStats = mealLogService.getWeeklyMealLogStats(userId, endDate);
+        log.info("주간 식단 통계 요청 날짜 : mealDate={}", date);
+        return ResponseEntity.ok(weeklyStats);
+    }
+
     // 식단 기록 상세 조회
     @GetMapping("/{logId}")
     public ResponseEntity<MealLogResponseDto> getDetailMealLog(@PathVariable Long logId, @AuthenticationPrincipal UserDetails userDetails) throws NotFoundException {

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dao/MealLogDAO.java
@@ -30,7 +30,7 @@ public interface MealLogDAO {
     void insertMealLog(MealLog mealLog);
 
     /* 전체 식단 기록 조회 */
-    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, img_url AS imgUrl, " +
+    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, m.img_url AS imgUrl, " +
             "m.meal_type AS mealType, m.quantity, " +
             "f.calories*m.quantity/100 AS calories, f.carbs*m.quantity/100 AS carbs, f.sugar*m.quantity/100 AS sugar, " +
             "f.protein*m.quantity/100 AS protein, f.fat*m.quantity/100 AS fat " + // SELECT 컬럼과 DTO 필드가 정확히 일치해야 하기 때문에 Alias를 사용
@@ -40,7 +40,7 @@ public interface MealLogDAO {
     List<MealLogResponseDto> getAllMealLogs(Long userId);
 
     /* 특정 날짜 식단 기록 조회 */
-    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, img_url AS imgUrl, " +
+    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, m.img_url AS imgUrl, " +
             "m.meal_type AS mealType, m.quantity, " +
             "f.calories*m.quantity/100 AS calories, f.carbs*m.quantity/100 AS carbs, f.sugar*m.quantity/100 AS sugar, " +
             "f.protein*m.quantity/100 AS protein, f.fat*m.quantity/100 AS fat " + // SELECT 컬럼과 DTO 필드가 정확히 일치해야 하기 때문에 Alias를 사용
@@ -52,15 +52,25 @@ public interface MealLogDAO {
     List<MealLogResponseDto> findByUserAndDate(@Param("userId") Long userId, @Param("mealDate") LocalDate mealDate);
 
     /* 특정 날짜 식단 통계 조회 */
-    @Select("Select sum(f.calories*m.quantity/100) AS totalCalories, sum(f.carbs*m.quantity/100) AS totalCarbs, " +
-            "sum(f.sugar*m.quantity/100) AS totalSugar, sum(f.protein*m.quantity/100) AS totalProtein, sum(f.fat*m.quantity/100) AS totalFat " +
+    @Select("Select m.meal_date AS date, sum(f.calories * m.quantity/100) AS totalCalories, sum(f.carbs * m.quantity/100) AS totalCarbs, " +
+            "sum(f.sugar * m.quantity/100) AS totalSugar, sum(f.protein * m.quantity/100) AS totalProtein, sum(f.fat * m.quantity/100) AS totalFat " +
             "From MealLog m " +
             "Join Food f ON m.food_id = f.food_id " +
             "Where m.user_id=#{userId} AND m.meal_date=#{mealDate}")
     MealLogStatsDto getDailyMealStats(@Param("userId") Long userId, @Param("mealDate") LocalDate mealDate);
 
+    /* 해당 기간(startDate ~ endDate)의 일별 식단 통계 조회 */
+    @Select("Select m.meal_date AS date, sum(f.calories*m.quantity/100) AS totalCalories, sum(f.carbs*m.quantity/100) AS totalCarbs, " +
+            "sum(f.sugar*m.quantity/100) AS totalSugar, sum(f.protein*m.quantity/100) AS totalProtein, sum(f.fat*m.quantity/100) AS totalFat " +
+            "From MealLog m " +
+            "Join Food f ON m.food_id = f.food_id " +
+            "Where m.user_id=#{userId} AND m.meal_date Between #{startDate} And #{endDate}" +
+            "Group By m.meal_date " +
+            "Order By m.meal_date ASC")
+    List<MealLogStatsDto> getDailyStatsForDateRange(Long userId, LocalDate startDate, LocalDate endDate);
+
     /* 식단 기록 상세 조회 */
-    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, img_url AS imgUrl, " +
+    @Select("Select m.log_id AS logId, f.name AS foodName, f.food_id AS foodId, m.img_url AS imgUrl, " +
             "m.meal_type AS mealType, m.quantity, " +
             "f.calories*m.quantity/100 AS calories, f.carbs*m.quantity/100 AS carbs, f.sugar*m.quantity/100 AS sugar, " +
             "f.protein*m.quantity/100 AS protein, f.fat*m.quantity/100 AS fat " + // SELECT 컬럼과 DTO 필드가 정확히 일치해야 하기 때문에 Alias를 사용
@@ -73,4 +83,6 @@ public interface MealLogDAO {
     @Delete("Delete From MealLog " +
             "Where user_id = #{userId} AND log_id = #{logId}")
     void deleteMealLog(Long userId, Long logId);
+
+
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogStatsDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/dto/MealLogStatsDto.java
@@ -5,16 +5,23 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Getter
 @Setter
 @Builder
 // 식단 통계 조회 DTO
 public class MealLogStatsDto {
+    private LocalDate date;
     private BigDecimal totalCalories;
     private BigDecimal totalCarbs;
     private BigDecimal totalSugar;
     private BigDecimal totalProtein;
     private BigDecimal totalFat;
 
+
+    // 기록이 없는 요청을 위한 생성자
+    public static MealLogStatsDto empty(LocalDate date) {
+         return new MealLogStatsDto(date, BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0));
+    }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogService.java
@@ -21,4 +21,6 @@ public interface MealLogService {
     List<MealLogResponseDto> getAllMealLogs(Long userId);
 
     MealLogResponseDto getDetailMealLog(Long userId, Long logId) throws NotFoundException;
+
+    List<MealLogStatsDto> getWeeklyMealLogStats(Long userId, LocalDate endDate);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
@@ -14,8 +14,11 @@ import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -66,6 +69,42 @@ public class MealLogServiceIml implements MealLogService{
         return mealLogDAO.getDailyMealStats(userId, mealDate);
     }
 
+    /* 주간 식단 통계 조회 - mealDate를 포함한 이전 7일간의 각 일별 통계 리스트 반환 */
+    @Override
+    public List<MealLogStatsDto> getWeeklyMealLogStats(Long userId, LocalDate endDate) {
+        // 1. 통계 기간의 시작일 계산 (endDate로부터 6일 전)
+        // 예: endDate가 2025-05-01 이면 startDate는 2025-04-25
+        // 예: endDate가 2025-01-01 이면 startDate는 2024-12-26 (연도, 월 자동 계산)
+        LocalDate startDate = endDate.minusDays(6);
+
+        // 2. DAO를 통해 해당 기간(startDate ~ endDate)의 일별 식단 통계 데이터 가져옴
+        // 이 DAO 메소드는 날짜별로 그룹화된 통계 DTO 리스트를 반환하도록 설계
+        // 만약 특정 날짜에 기록이 없다면, 해당 날짜의 DTO는 이 리스트에 포함되지 않을 수 있음.
+        List<MealLogStatsDto> statsFromDB = mealLogDAO.getDailyStatsForDateRange(userId, startDate, endDate);
+
+        // 3. 결과를 날짜별로 쉽게 조회할 수 있도록 Map으로 변환
+        // key : 날짜, value : MealLogStatsDto 객체
+        Map<LocalDate, MealLogStatsDto> statsMap = statsFromDB.stream()
+                .collect(Collectors.toMap(MealLogStatsDto::getDate, dto -> dto));
+
+        // 7일치 일별 통계 식단 기록 반환
+        List<MealLogStatsDto> weeklyStatsList = new ArrayList<>();
+        LocalDate currentDate = startDate;
+        for(int i = 0; i < 7; i++) {
+            MealLogStatsDto dailyStats = statsMap.get(currentDate);
+
+            // currentDate에 해당하는 키가 statsMap 없을 때
+            // 즉, DB에서 해당 날짜의 통계가 없는 경우
+            if(dailyStats==null) {
+                dailyStats = MealLogStatsDto.empty(currentDate);
+            }
+
+            weeklyStatsList.add(dailyStats);
+            currentDate = currentDate.plusDays(1); // 다음 날짜로 이동
+        }
+        return weeklyStatsList;
+    }
+
     /* 식단 기록 상세 조회 */
     @Override
     public MealLogResponseDto getDetailMealLog(Long userId, Long logId) {
@@ -80,7 +119,6 @@ public class MealLogServiceIml implements MealLogService{
 
         return mealLogDAO.getDetailMealLog(userId, logId);
     }
-
 
     /* 식단 기록 삭제 */
     @Override


### PR DESCRIPTION
## 개요

파라미터로 받은 날짜를 기준으로 이전 7일의 식단 통계 기록을 반환하는 로직 구현

<!---- Resolves: #67 -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

- 파라미터로 받은 date는 endDate가 되고 그로부터 7일 동안의 식단 통계를 리스트로 반환
- LocalDate의 minusDays() 메서드를 사용하여 startDate를 계산
- DAO에서 해당 기간(startDate ~ endDate)의 일별 식단 통계 데이터 반환
- 결과를 날짜별로 쉽게 조회할 수 있도록 Map으로 변환하고 반환된 데이터에 해당 날짜가 없으면 데이터 0을 반환하도록 설계

## 스크린샷
📸 해당 날짜의 데이터가 없는 경우도 고려
<img width="852" alt="스크린샷 2025-05-16 오후 3 57 16" src="https://github.com/user-attachments/assets/281e688f-15df-4751-a69f-f4537a9afea1" />

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).