### PR TITLE
[FE] 식단기록 프론트 영양성분 통계 및 기록 조회

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "react-query": "^3.39.3",
         "react-router-dom": "^6.30.0",
         "react-scripts": "5.0.1",
-        "recharts": "^2.10.0"
+        "recharts": "^2.15.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -15267,7 +15267,6 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
       "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -17603,20 +17602,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.30.0",
     "react-scripts": "5.0.1",
-    "recharts": "^2.10.0"
+    "recharts": "^2.15.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/meallogs/MealLogCalendar.js
+++ b/frontend/src/components/meallogs/MealLogCalendar.js
@@ -4,6 +4,7 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { ko } from 'date-fns/locale';
+import { format } from 'date-fns';
 import { motion } from 'framer-motion';
 import { styled } from '@mui/material/styles';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -40,13 +41,13 @@ const StyledCalendar = styled(Box)(({ theme }) => ({
   },
 }));
 
-const MealLogCalendar = () => {
+const MealLogCalendar = ({ onDateSelect }) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const [hasMeal, setHasMeal] = useState(false);
 
   const handleDateChange = (newDate) => {
     setSelectedDate(newDate);
-    // 여기에 선택된 날짜에 대한 처리 로직 추가
+    const formattedDate = format(newDate, 'yyyy-MM-dd');
+    onDateSelect(formattedDate);
   };
 
   return (

--- a/frontend/src/components/meallogs/RecentMeals.js
+++ b/frontend/src/components/meallogs/RecentMeals.js
@@ -1,93 +1,74 @@
-import React, { useState, useEffect } from 'react';
-import { Box, Typography, CircularProgress, List, ListItem, ListItemText, ListItemAvatar, Avatar } from '@mui/material';
-import { mealLogService } from '../../services/mealLogService';
+import React from 'react';
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+  Chip,
+} from '@mui/material';
+import { format, parseISO } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
-const RecentMeals = () => {
-  const [meals, setMeals] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const fetchRecentMeals = async () => {
-      try {
-        setLoading(true);
-        const data = await mealLogService.getRecentMealLogs();
-        setMeals(data);
-      } catch (err) {
-        setError('최근 식단 기록을 불러오는데 실패했습니다.');
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchRecentMeals();
-  }, []);
-
-  if (loading) {
+const RecentMeals = ({ selectedDate, mealLogs }) => {
+  if (!mealLogs || mealLogs.length === 0) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
-        <CircularProgress />
+      <Box p={3} textAlign="center">
+        <Typography>선택한 날짜에 기록된 식단이 없습니다.</Typography>
       </Box>
     );
   }
 
-  if (error) {
-    return (
-      <Box p={3}>
-        <Typography color="error">{error}</Typography>
-      </Box>
-    );
-  }
-
-  if (!meals.length) {
-    return (
-      <Box p={3}>
-        <Typography>최근 식단 기록이 없습니다.</Typography>
-      </Box>
-    );
-  }
+  const formatDate = (dateString) => {
+    try {
+      return format(parseISO(dateString), 'yyyy년 MM월 dd일', { locale: ko });
+    } catch (error) {
+      console.error('날짜 형식 변환 오류:', error);
+      return '날짜 정보 없음';
+    }
+  };
 
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
-        최근 식단 기록
+        {formatDate(selectedDate)} 식단
       </Typography>
       <List>
-        {meals.map((meal) => (
-          <ListItem
-            key={meal.logId}
-            sx={{
-              mb: 2,
-              bgcolor: '#f5f5f5',
-              borderRadius: 2,
-              '&:hover': {
-                bgcolor: '#eeeeee',
-              },
-            }}
-          >
-            <ListItemAvatar>
-              <Avatar
-                src={meal.imgUrl}
-                alt={meal.foodName}
-                sx={{ width: 56, height: 56 }}
+        {mealLogs.map((log, index) => (
+          <React.Fragment key={log.id || index}>
+            <ListItem
+              sx={{
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                py: 2
+              }}
+            >
+              <Box display="flex" alignItems="center" width="100%" mb={1}>
+                <Chip
+                  label={log.mealType}
+                  size="small"
+                  color="primary"
+                />
+              </Box>
+              <ListItemText
+                primary={
+                  <Typography variant="body1">
+                    {log.foodName}
+                  </Typography>
+                }
+                secondary={
+                  <Box mt={1}>
+                    <Typography variant="body2" color="text.secondary">
+                      칼로리: {log.calories}kcal | 단백질: {log.protein}g | 
+                      탄수화물: {log.carbs}g | 지방: {log.fat}g
+                    </Typography>
+                  </Box>
+                }
               />
-            </ListItemAvatar>
-            <ListItemText
-              primary={meal.foodName}
-              secondary={
-                <>
-                  <Typography component="span" variant="body2" color="text.primary">
-                    {meal.mealType} - {meal.quantity}인분
-                  </Typography>
-                  <br />
-                  <Typography component="span" variant="body2" color="text.secondary">
-                    {meal.calories} kcal | 단백질 {meal.protein}g | 탄수화물 {meal.carbs}g | 지방 {meal.fat}g
-                  </Typography>
-                </>
-              }
-            />
-          </ListItem>
+            </ListItem>
+            {index < mealLogs.length - 1 && <Divider />}
+          </React.Fragment>
         ))}
       </List>
     </Box>

--- a/frontend/src/pages/MealLogs.js
+++ b/frontend/src/pages/MealLogs.js
@@ -1,14 +1,73 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { Box, Container, Grid, Paper, Typography } from '@mui/material';
+import { Box, Container, Grid, Paper, CircularProgress } from '@mui/material';
 import NutritionSummary from '../components/meallogs/NutritionSummary';
 import RecentMeals from '../components/meallogs/RecentMeals';
-import WeeklyBalanceChart from '../components/meallogs/WeeklyBalanceChart';
 import MealLogCalendar from '../components/meallogs/MealLogCalendar';
+import { mealLogService } from '../services/mealLogService';
+import { format } from 'date-fns';
 
 const MealLogs = () => {
   const auth = useAuth();
+  const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
+  const [mealLogs, setMealLogs] = useState([]);
+  const [dailyStats, setDailyStats] = useState(null);
+  const [weeklyStats, setWeeklyStats] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchData = async (date) => {
+    try {
+      // 데이터 페칭 전에 기존 데이터 초기화
+      setMealLogs([]);
+      setDailyStats(null);
+      setWeeklyStats([]);
+      setError(null);
+      setLoading(true);
+
+      // 병렬로 데이터 요청
+      const [logsResponse, statsResponse, weeklyStatsResponse] = await Promise.allSettled([
+        mealLogService.getMealLogsByDate(date),
+        mealLogService.getMealLogStatsByDate(date),
+        mealLogService.getWeeklyMealLogs(date)
+      ]);
+
+      // 각 응답 처리
+      if (logsResponse.status === 'fulfilled') {
+        setMealLogs(logsResponse.value || []);
+      } else {
+        console.error('식단 기록 조회 실패:', logsResponse.reason);
+      }
+
+      if (statsResponse.status === 'fulfilled') {
+        setDailyStats(statsResponse.value || null);
+      } else {
+        console.error('일일 통계 조회 실패:', statsResponse.reason);
+      }
+
+      if (weeklyStatsResponse.status === 'fulfilled') {
+        setWeeklyStats(weeklyStatsResponse.value || []);
+      } else {
+        console.error('주간 통계 조회 실패:', weeklyStatsResponse.reason);
+      }
+
+    } catch (err) {
+      setError('데이터를 불러오는데 실패했습니다.');
+      console.error('Error fetching meal log data:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 날짜가 변경될 때마다 데이터 새로 불러오기
+  useEffect(() => {
+    fetchData(selectedDate);
+  }, [selectedDate]);
+
+  const handleDateSelect = (date) => {
+    setSelectedDate(date);
+  };
 
   if (!auth.isAuthenticated) {
     return <Navigate to="/login" replace />;
@@ -16,35 +75,35 @@ const MealLogs = () => {
 
   return (
     <Container maxWidth="xl" sx={{ py: 4 }}>
-      <Typography variant="h4" gutterBottom sx={{ mb: 4 }}>
-        식단 기록
-      </Typography>
       <Grid container spacing={3}>
         {/* 식단 기록 캘린더 */}
-        <Grid item xs={12} md={6}>
-          <Paper elevation={3} sx={{ p: 3, height: '100%' }}>
-            <MealLogCalendar />
+        <Grid item xs={12} md={4}>
+          <Paper elevation={3} sx={{ height: '100%' }}>
+            <MealLogCalendar onDateSelect={handleDateSelect} />
           </Paper>
         </Grid>
 
-        {/* 주간 영양소 밸런스 차트 */}
-        <Grid item xs={12} md={6}>
-          <Paper elevation={3} sx={{ p: 3, height: '100%' }}>
-            <WeeklyBalanceChart />
+        {/* 식단 기록 목록 */}
+        <Grid item xs={12} md={4}>
+          <Paper elevation={3} sx={{ p: 3, height: '100%', position: 'relative' }}>
+            {loading ? (
+              <Box display="flex" justifyContent="center" alignItems="center" minHeight={400}>
+                <CircularProgress />
+              </Box>
+            ) : (
+              <RecentMeals selectedDate={selectedDate} mealLogs={mealLogs} />
+            )}
           </Paper>
         </Grid>
 
-        {/* 식단 기록 */}
-        <Grid item xs={12} md={6}>
+        {/* 영양소 통계 */}
+        <Grid item xs={12} md={4}>
           <Paper elevation={3} sx={{ p: 3, height: '100%' }}>
-            <RecentMeals />
-          </Paper>
-        </Grid>
-
-        {/* 오늘의 영양소 요약 */}
-        <Grid item xs={12} md={6}>
-          <Paper elevation={3} sx={{ p: 3, height: '100%' }}>
-            <NutritionSummary />
+            <NutritionSummary
+              selectedDate={selectedDate}
+              dailyStats={dailyStats}
+              weeklyStats={weeklyStats}
+            />
           </Paper>
         </Grid>
       </Grid>

--- a/frontend/src/services/mealLogService.js
+++ b/frontend/src/services/mealLogService.js
@@ -96,42 +96,15 @@ export const mealLogService = {
     }
   },
 
-  // 주간 식단 기록 조회
-  getWeeklyMealLogs: async () => {
+  // 주간 식단 통계 조회
+  getWeeklyMealLogs: async (date) => {
     try {
-      const today = new Date();
-      const promises = [];
-      
-      // 현재 날짜부터 6일 전까지의 날짜 배열 생성
-      for (let i = 6; i >= 0; i--) {
-        const date = new Date(today);
-        date.setDate(today.getDate() - i);
-        const dateStr = date.toISOString().split('T')[0];
-        
-        promises.push(
-          axiosInstance.get('/meallogs/stats', {
-            params: { date: dateStr }
-          }).then(response => ({
-            date: dateStr,
-            ...response.data
-          })).catch(error => {
-            // 통계 데이터가 없는 경우 0으로 채우기
-            console.log(`${dateStr} 통계 데이터 없음`);
-            return {
-              date: dateStr,
-              calories: 0,
-              protein: 0,
-              carbs: 0,
-              fat: 0
-            };
-          })
-        );
-      }
-
-      const responses = await Promise.all(promises);
-      return responses;
+      const response = await axiosInstance.get('/meallogs/stats/weekly', {
+        params: { date }
+      });
+      return response.data;
     } catch (error) {
-      console.error('주간 식단 기록 조회 실패:', error);
+      console.error('주간 식단 통계 조회 실패:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## 개요
<!---- Resolves: #71  -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용


1️⃣ 특정 날짜 식단 기록 조회 UI 및 기능 개발

사용자로부터 특정 날짜를 선택할 수 있는 UI 제공 (예: 캘린더 컴포넌트)
수신된 특정 날짜의 식단 기록 리스트를 화면에 구성하여 표시
해당 날짜에 식단 기록이 없을 경우 "해당 날짜에 기록된 식단이 없습니다." 메시지 표시

2️⃣ 특정 날짜 식단 통계 조회 UI 및 기능 개발

사용자가 특정 날짜의 식단 통계를 볼 수 있도록 UI 구성 (예: 식단 기록 페이지 내 통계 섹션 또는 별도 통계 탭)
수신된 일일 식단 통계 데이터(MealLogStatsDto: 예: 총 칼로리, 주요 영양소 합계 등)를 화면에 명확하게 시각화하여 표시
해당 날짜에 통계 데이터가 없거나 집계할 식단 기록이 없을 경우 적절한 메시지 표시

3️⃣ 주간 식단 통계 조회 UI 및 기능 개발

사용자가 특정 날짜를 기준으로 주간(7일) 식단 통계를 볼 수 있도록 그래프 UI 구성
사용자로부터 기준 날짜를 선택할 수 있는 UI 제공 (예: 캘린더에서 날짜 선택 시, 해당 날짜를 포함한 7일)

## 스크린샷

<img width="1512" alt="스크린샷 2025-05-16 오후 6 07 29" src="https://github.com/user-attachments/assets/e371db83-5fb5-45b8-bd99-efd2c33ac1fd" />

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).