### PR TITLE
[BE] 댓글/대댓글 생성 및 조회 기능

### DIFF
--- a/Backend/data/schema.sql
+++ b/Backend/data/schema.sql
@@ -127,7 +127,7 @@ CREATE TABLE Comment (
                          board_id BIGINT NOT NULL COMMENT '댓글이 달린 게시글 ID (Board 테이블 PK 참조)',
                          user_id BIGINT NOT NULL COMMENT '댓글 작성자 ID (User 테이블 PK 참조)',
                          content TEXT NOT NULL COMMENT '댓글 내용',
-                         parent_comment_id BIGINT NULL COMMENT '부모 댓글 ID (대댓글인 경우)', // 대댓글 위한 컬럼 추가
+                         parent_comment_id BIGINT NULL COMMENT '부모 댓글 ID (대댓글인 경우)', -- 대댓글 위한 컬럼 추가
                          create_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '댓글 생성 일시',
                          update_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '댓글 수정 일시',
                          CONSTRAINT fk_comment_board FOREIGN KEY (board_id) REFERENCES Board(board_id)
@@ -136,7 +136,8 @@ CREATE TABLE Comment (
                              ON DELETE CASCADE, -- 사용자 삭제 시 해당 사용자 댓글 모두 삭제 (정책에 따라 변경 가능)
                          CONSTRAINT fk_comment_parent FOREIGN KEY (parent_comment_id) REFERENCES Comment(comment_id)
                              ON DELETE CASCADE, -- 부모 댓글 삭제 시 자식 댓글도 삭제 (정책에 따라 변경 가능)
-                         INDEX idx_comment_board (board_id) COMMENT '게시글별 댓글 조회를 위한 인덱스'
+                         INDEX idx_comment_board (board_id) COMMENT '게시글별 댓글 조회를 위한 인덱스',
+                         INDEX idx_board_user (board_id, user_id) COMMENT '게시글 ID 및 사용자 ID 복합 인덱스'
 ) ENGINE=InnoDB COMMENT '게시글 댓글 정보';
 
 select * from food;

--- a/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
@@ -58,8 +58,8 @@ public class SecurityConfig {
                                 "/api/auth/**", // 인증 관련 API (로그인 시작, 콜백 등)
                                 "/api/foods", // 음식 검색 (GET) - 명세상 모든 사용자 접근 가능
                                 "/api/foods/{foodId}", // 음식 상세 조회 (GET) - 명세상 모든 사용자 접근 가능
-                                "/api/board", // 게시판 목록 조회 (GET)
-                                "/api/board/{postId}" // 게시판 상세 조회 (GET)
+                                "/api/boards", // 게시판 목록 조회 (GET)
+                                "/api/boards/{boardId}" // 게시판 상세 조회 (GET)
                                 // 필요시 h2-console 접근 허용 (개발용)
                                 // , "/h2-console/**"
                         ).permitAll() // 위 경로는 인증 없이 접근 허용

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.ssafy.happymeal.domain.board.controller;
 
 import com.ssafy.happymeal.domain.board.dto.*;
 import com.ssafy.happymeal.domain.board.service.BoardService;
+import com.ssafy.happymeal.domain.comment.entity.Comment;
 import com.ssafy.happymeal.domain.commonDto.PageResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -169,5 +171,35 @@ public class BoardController {
 
         return ResponseEntity.ok(boardDetailResponse);
     }
+
+    /* 댓글/대댓글 작성(Create)
+    * POST api/boards/{boardId}/comments
+    * 접근 권한 : USER */
+    @PostMapping("/{boardId}/comments")
+    public ResponseEntity<?> createComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long boardId,
+            @Valid @RequestBody CommentRequestDto requestDto) {
+
+        Long userId = Long.parseLong(userDetails.getUsername());
+        log.info("댓글 작성 요청 수신 - userId: {}, boardId: {}", userId, boardId);
+        Comment createComment = boardService.createComment(userId, boardId, requestDto);
+        return ResponseEntity.ok(createComment);
+
+    }
+
+    /* 게시글 내의 댓글/대댓글(1개) 조회
+     * GET api/boards/{boardId}/comments
+     * 접근 권한 : ALL */
+    @GetMapping("/{boardId}/comments")
+    public ResponseEntity<List<CommentResponseDto>> getBoardComments(@PathVariable Long boardId) {
+        log.info("댓글 조회 요청 게시글 boardId: {}", boardId);
+        List<CommentResponseDto> comments = boardService.getBoardComments(boardId);
+        if(comments == null || comments.isEmpty()) {
+            return ResponseEntity.ok(Collections.emptyList()); // 비어있는 리스트 반환
+        }
+        return ResponseEntity.ok(comments);
+    }
+
 
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardDAO.java
@@ -1,10 +1,8 @@
 package com.ssafy.happymeal.domain.board.dao;
 
-import com.ssafy.happymeal.domain.board.dto.BoardAuthorSearchCriteria;
-import com.ssafy.happymeal.domain.board.dto.BoardCategoryCriteria;
-import com.ssafy.happymeal.domain.board.dto.BoardResponseDto;
-import com.ssafy.happymeal.domain.board.dto.BoardTitleSearchCriteria;
+import com.ssafy.happymeal.domain.board.dto.*;
 import com.ssafy.happymeal.domain.board.entity.Board;
+import com.ssafy.happymeal.domain.comment.entity.Comment;
 import org.apache.ibatis.annotations.*;
 
 import java.util.List;
@@ -202,6 +200,9 @@ public interface BoardDAO {
 
     @Update("UPDATE Board SET views = views + 1 WHERE board_id = #{boardId}")
     int incrementViewCount(@Param("boardId") Long boardId);
+
+
+
 
 
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/CommentRequestDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/CommentRequestDto.java
@@ -1,0 +1,15 @@
+package com.ssafy.happymeal.domain.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentRequestDto {
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+    private Long parentCommentId; // 없으면 null
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/CommentResponseDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/CommentResponseDto.java
@@ -1,0 +1,30 @@
+package com.ssafy.happymeal.domain.board.dto;
+
+import com.ssafy.happymeal.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentResponseDto {
+    private Long commentId;
+    private Long boardId;
+    private Long userId;
+    private long parentCommentId;
+    private String nickname;
+    private String content;
+    private Timestamp createAt;
+    private Timestamp updateAt;
+    private List<CommentResponseDto> replies = new ArrayList<>(); // 대댓글을 담을 리스트
+//    private long childReplyCount = 0; // 이 댓글의 총 직계 자식 수를 알려주면, 1단계 대댓글 DTO도 자신이 대댓글을 더 가지고 있는지 표시 가능
+
+
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.ssafy.happymeal.domain.board.service;
 
 import com.ssafy.happymeal.domain.board.dto.*;
+import com.ssafy.happymeal.domain.comment.entity.Comment;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -20,4 +21,10 @@ public interface BoardService {
 
     // === 신규 기능: 게시글 상세 조회 (블록 및 작성자 정보 포함) ===
     BoardDetailResponseDto getBoardDetailById(Long boardId);
+
+    // 댓글/대댓글 생성
+    Comment createComment(Long userId, Long boardId, CommentRequestDto requestDto);
+
+    // 게시글의 댓글/대댓글(1개) 조회
+    List<CommentResponseDto> getBoardComments(Long boardId);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/controller/CommentController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/controller/CommentController.java
@@ -1,0 +1,18 @@
+package com.ssafy.happymeal.domain.comment.controller;
+
+import com.ssafy.happymeal.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
@@ -1,0 +1,52 @@
+package com.ssafy.happymeal.domain.comment.dao;
+
+import com.ssafy.happymeal.domain.board.dto.CommentResponseDto;
+import com.ssafy.happymeal.domain.comment.entity.Comment;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface CommentDAO {
+
+    // 댓글 생성
+    @Insert("Insert into Comment(board_id, user_id, content, parent_comment_id) " +
+            "Values (#{boardId}, #{userId}, #{content}, #{parentCommentId})")
+    @Options(useGeneratedKeys = true, keyProperty = "commentId", keyColumn = "comment_id")
+    int saveComment(Comment comment);
+
+    // 댓글 ID와 부모 댓글 ID 일치 확인
+    @Select("select * " +
+            "from Comment " +
+            "where comment_id=#{commentId} and board_id=#{boardId}")
+    Optional<Comment> findCommentById(Long commentId, Long boardId);
+
+
+    // 특정 게시글의 모든 최상위 댓글 목록 조회
+    @Select("""
+            <script>
+            Select c.comment_id, c.board_id, c.user_id, c.parent_comment_id, u.nickname, c.content, c.create_at, c.update_at
+            From Comment c
+            Inner Join User u On c.user_id = u.user_id
+            Where c.board_id=#{boardId} And c.parent_comment_id is NULL
+            Order by c.create_at
+            </script>
+            """)
+    List<CommentResponseDto> findTopLevelCommentsByBoardId(Long boardId);
+
+    // 여러 부모 댓글 ID에 해당하는 모든 직계 자식 댓글 조회
+    @Select("""
+            <script>
+            Select c.comment_id, c.board_id, c.user_id, c.parent_comment_id, u.nickname, c.content, c.create_at, c.update_at
+            From Comment c
+            Inner Join User u On c.user_id = u.user_id
+            Where c.parent_comment_id In
+            <foreach item="parentId" collection="parentCommentIds" open="(" separator="," close=")">
+                #{parentId}
+            </foreach>
+            Order by c.create_at
+            </script>
+            """)
+    List<CommentResponseDto> findChildRepliesByParentId(@Param("parentCommentIds") List<Long> parentCommentIds);
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/entity/Comment.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/entity/Comment.java
@@ -1,0 +1,21 @@
+package com.ssafy.happymeal.domain.comment.entity;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+    private Long commentId;
+    private Long boardId;
+    private Long userId;
+    private String content;
+    private Long parentCommentId; // 대댓글을 위한 컬럼
+    private Timestamp createAt;
+    private Timestamp updateAt;
+
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentService.java
@@ -1,0 +1,4 @@
+package com.ssafy.happymeal.domain.comment.service;
+
+public interface CommentService {
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,9 @@
+package com.ssafy.happymeal.domain.comment.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CommentServiceImpl implements CommentService {
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/controller/UserController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/controller/UserController.java
@@ -2,15 +2,11 @@ package com.ssafy.happymeal.domain.user.controller;
 
 import com.ssafy.happymeal.domain.commonDto.PageResponse;
 import com.ssafy.happymeal.domain.user.dto.*;
-import com.ssafy.happymeal.domain.user.entity.User;
 import com.ssafy.happymeal.domain.user.service.UserService;
-import com.ssafy.happymeal.domain.user.service.UserServiceImpl;
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/user/service/UserServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/user/service/UserServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
## 개요

📁 SecurityConfig 인가 규칙 설정 : permitAll api/board/{postId} -> api/boards/{boardId} 로 변경

<!---- Resolves: #75  -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

✅ 댓글/대댓글 생성 시 parent_comment_id가 null값이면 최상위 댓글이고, null이 아니면 하위댓글임
✔️ 댓글 생성 시 부모댓글 유효성 체크(요청 파라미터 안의 부모 아이디가 DB의 comment_id에 존재하는지 여부)
✅ 게시글에 댓글이 존재하지 않으면 빈 리스트를 반환하도록 설정
✅ CommentResponseDto에 대댓글을 담을 리스트 필드 생성해서 댓글과 대댓글 조회 요청을 한 번에 처리

## 스크린샷

**📸 댓글 작성**
<img width="861" alt="image" src="https://github.com/user-attachments/assets/5b71cdfd-657c-4902-94f9-ac0963c766ff" />

**📸 대댓글 작성**
<img width="850" alt="image" src="https://github.com/user-attachments/assets/ee282684-f4ff-41da-ad6d-4d1b697e79b0" />

**📸 댓글/대댓글 조회**
![image](https://github.com/user-attachments/assets/8d8e2266-3116-446a-8d04-95b082c71389)

**📸 부모 댓글 유효성 체크**
![image](https://github.com/user-attachments/assets/6a81c660-3e64-49c9-bcdc-28bbf564753f)

## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).