### PR TITLE
댓글 삭제 BE/FE 구현

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/controller/CommentController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/controller/CommentController.java
@@ -1,11 +1,17 @@
 package com.ssafy.happymeal.domain.comment.controller;
 
 import com.ssafy.happymeal.domain.comment.service.CommentService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -15,4 +21,31 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    @DeleteMapping("/{boardId}/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long userId = Long.parseLong(userDetails.getUsername());
+        log.info("댓글 삭제 요청 수신 - userId: {}, boardId: {}, commentId: {}", userId, boardId, commentId);
+
+        try {
+            commentService.deleteComment(userId, boardId, commentId);
+            return ResponseEntity.ok().build();
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 삭제 실패 - 댓글을 찾을 수 없음: commentId={}", commentId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Not Found", "message", e.getMessage()));
+        } catch (IllegalStateException e) {
+            log.warn("댓글 삭제 실패 - 권한 없음: commentId={}, userId={}", commentId, userId);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Forbidden", "message", e.getMessage()));
+        } catch (Exception e) {
+            log.error("댓글 삭제 중 오류 발생: commentId={}, userId={}", commentId, userId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Internal Server Error", "message", "서버 내부 처리 중 오류가 발생했습니다."));
+        }
+    }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
@@ -52,4 +52,8 @@ public interface CommentDAO {
 
     @Delete("DELETE FROM Comment WHERE board_id = #{boardId}")
     int deleteCommentsByBoardId(@Param("boardId") Long boardId);
+
+    // 댓글 삭제 (CASCADE 설정으로 인해 자식 댓글도 자동 삭제됨)
+    @Delete("DELETE FROM Comment WHERE comment_id = #{commentId}")
+    int deleteComment(@Param("commentId") Long commentId);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentService.java
@@ -1,4 +1,5 @@
 package com.ssafy.happymeal.domain.comment.service;
 
 public interface CommentService {
+    void deleteComment(Long userId, Long boardId, Long commentId);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
@@ -1,9 +1,34 @@
 package com.ssafy.happymeal.domain.comment.service;
 
+import com.ssafy.happymeal.domain.comment.dao.CommentDAO;
+import com.ssafy.happymeal.domain.comment.entity.Comment;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
+    
+    private final CommentDAO commentDAO;
+
+    @Override
+    @Transactional
+    public void deleteComment(Long userId, Long boardId, Long commentId) {
+        // 댓글 존재 여부 및 권한 확인
+        Comment comment = commentDAO.findCommentById(commentId, boardId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
+
+        // 댓글 작성자 확인
+        if (!comment.getUserId().equals(userId)) {
+            throw new IllegalStateException("댓글을 삭제할 권한이 없습니다.");
+        }
+
+        // 댓글 삭제 (CASCADE 설정으로 인해 자식 댓글도 자동 삭제됨)
+        commentDAO.deleteComment(commentId);
+        log.info("댓글 삭제 완료 - commentId: {}", commentId);
+    }
 }

--- a/frontend/src/pages/BoardDetail.js
+++ b/frontend/src/pages/BoardDetail.js
@@ -198,6 +198,21 @@ const BoardDetail = () => {
     }
   };
 
+  // 댓글 삭제 핸들러 추가
+  const handleDeleteComment = async (commentId) => {
+    if (!id || !commentId) return;
+    
+    if (window.confirm('정말로 이 댓글을 삭제하시겠습니까?')) {
+      try {
+        await BoardService.deleteComment(id, commentId);
+        await refreshComments(); // 댓글 목록 새로고침
+      } catch (error) {
+        console.error('댓글 삭제 실패:', error);
+        setError('댓글 삭제에 실패했습니다.');
+      }
+    }
+  };
+
   if (loading) {
     return (
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
@@ -394,13 +409,23 @@ const BoardDetail = () => {
                             </Typography>
                           }
                         />
-                        <Button
-                          size="small"
-                          onClick={() => setReplyTo(comment.commentId)}
-                          sx={{ ml: 1 }}
-                        >
-                          답글
-                        </Button>
+                        <Box sx={{ display: 'flex', gap: 1 }}>
+                          <Button
+                            size="small"
+                            onClick={() => setReplyTo(comment.commentId)}
+                          >
+                            답글
+                          </Button>
+                          {user && Number(user.userId) === comment.userId && (
+                            <Button
+                              size="small"
+                              color="error"
+                              onClick={() => handleDeleteComment(comment.commentId)}
+                            >
+                              삭제
+                            </Button>
+                          )}
+                        </Box>
                       </Box>
                       
                       {/* 대댓글 작성 폼 */}
@@ -462,6 +487,15 @@ const BoardDetail = () => {
                                   </Typography>
                                 }
                               />
+                              {user && Number(user.userId) === reply.userId && (
+                                <Button
+                                  size="small"
+                                  color="error"
+                                  onClick={() => handleDeleteComment(reply.commentId)}
+                                >
+                                  삭제
+                                </Button>
+                              )}
                             </ListItem>
                           ))}
                         </List>

--- a/frontend/src/services/BoardService.js
+++ b/frontend/src/services/BoardService.js
@@ -153,6 +153,17 @@ const BoardService = {
       console.error('댓글 목록 조회 API 호출 실패:', error);
       throw error;
     }
+  },
+
+  // 댓글 삭제
+  deleteComment: async (boardId, commentId) => {
+    try {
+      const response = await axiosInstance.delete(`/comments/${boardId}/${commentId}`);
+      return response;
+    } catch (error) {
+      console.error('댓글 삭제 API 호출 실패:', error);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

# 댓글 삭제 기능 구현

## 기능 설명
- 사용자가 작성한 댓글에 대해서만 삭제 버튼이 표시됩니다.
- 부모 댓글이 삭제되면 관련된 모든 대댓글도 함께 삭제됩니다 (CASCADE 설정).

## 구현 내용

### 백엔드
1. `CommentController`
   - DELETE `/api/comments/{boardId}/{commentId}` 엔드포인트 추가
   - 인증된 사용자만 접근 가능 (`@PreAuthorize("isAuthenticated()")`)
   - 댓글 작성자 권한 확인 및 예외 처리

2. `CommentService`
   - 댓글 삭제 로직 구현
   - 댓글 존재 여부 및 작성자 권한 확인

3. `CommentDAO`
   - 댓글 삭제 쿼리 구현
   - CASCADE 설정으로 자식 댓글 자동 삭제

### 프론트엔드
1. `BoardService`
   - 댓글 삭제 API 호출 메서드 추가
   - DELETE `/comments/{boardId}/{commentId}`

2. `BoardDetail`
   - 댓글 삭제 핸들러 구현
   - 삭제 전 확인 대화상자 표시
   - 삭제 성공 시 댓글 목록 자동 새로고침
   - 댓글 작성자에게만 삭제 버튼 표시

## 스크린샷

내가 작성한 글에만 삭제버튼 보임
![스크린샷 2025-05-22 10 57 49](https://github.com/user-attachments/assets/83321dae-248f-4217-9885-f81fc08ad6c0)

삭제 버튼 누르면 뜨는 알림
![스크린샷 2025-05-22 10 58 03](https://github.com/user-attachments/assets/6e618626-3bdb-46b4-bc75-93b698aaafd0)

삭제하면 자식 댓글까지 모두 삭제
![스크린샷 2025-05-22 10 58 13](https://github.com/user-attachments/assets/51f9c9e0-d2f6-4018-a2af-e0428e6300b8)

## 공유사항 to 리뷰어


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).