### PR TITLE
Feature/#102

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardLikeDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardLikeDAO.java
@@ -10,9 +10,16 @@ public interface BoardLikeDAO {
     
     @Insert("INSERT INTO BoardLike (user_id, board_id, create_at) VALUES (#{userId}, #{boardId}, NOW())")
     int saveLike(BoardLike boardLike);
-    
+
+    @Update("update Board set likes_count=likes_count+1 where board_id = #{boardId}")
+    void updateLikeCount(BoardLike boardLike);
+
     @Delete("DELETE FROM BoardLike WHERE user_id = #{userId} AND board_id = #{boardId}")
     int deleteLike(@Param("userId") Long userId, @Param("boardId") Long boardId);
+
+    @Update("update Board set likes_count=likes_count-1 where board_id = #{boardId}")
+    void updateLikeCount2(@Param("boardId") Long boardId);
+
     
     @Select("SELECT * FROM BoardLike WHERE user_id = #{userId} AND board_id = #{boardId}")
     BoardLike findByUserIdAndBoardId(@Param("userId") Long userId, @Param("boardId") Long boardId);

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardServiceImpl.java
@@ -270,6 +270,8 @@ public class BoardServiceImpl implements BoardService{
 
         // 3. 게시글 삭제
         boardDAO.deleteBoard(boardId);
+
+
     }
 
     @Override

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/service/BoardServiceImpl.java
@@ -167,6 +167,7 @@ public class BoardServiceImpl implements BoardService{
             if(comment.getCommentId()==null) {
                 throw new IllegalArgumentException("commentId 생성 실패");
             }
+            commentDAO.updateCommentCount(comment);
             return comment;
         }
         // 저장 실패 시 반환 로직
@@ -284,6 +285,7 @@ public class BoardServiceImpl implements BoardService{
         if (existingLike != null) {
             // 이미 좋아요가 있는 경우 -> 좋아요 취소
             boardLikeDAO.deleteLike(userId, boardId);
+            boardLikeDAO.updateLikeCount2(boardId);
             board.setLikesCount(board.getLikesCount() - 1);
         } else {
             // 좋아요가 없는 경우 -> 좋아요 추가
@@ -292,6 +294,7 @@ public class BoardServiceImpl implements BoardService{
                     .boardId(boardId)
                     .build();
             boardLikeDAO.saveLike(newLike);
+            boardLikeDAO.updateLikeCount(newLike);
             board.setLikesCount(board.getLikesCount() + 1);
         }
         

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
@@ -65,4 +65,5 @@ public interface CommentDAO {
 
     @Update("update Board set comments_count=comments_count-#{commentCount}-1 where board_id=#{boardId}")
     void deleteCommentCount(@Param("boardId") Long boardId, @Param("commentCount") int commentCount);
+
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/dao/CommentDAO.java
@@ -16,6 +16,9 @@ public interface CommentDAO {
     @Options(useGeneratedKeys = true, keyProperty = "commentId", keyColumn = "comment_id")
     int saveComment(Comment comment);
 
+    @Update("update Board set comments_count=comments_count+1 where board_id=#{boardId}")
+    void updateCommentCount(Comment comment);
+
     // 댓글 ID와 부모 댓글 ID 일치 확인
     @Select("select * " +
             "from Comment " +
@@ -53,7 +56,13 @@ public interface CommentDAO {
     @Delete("DELETE FROM Comment WHERE board_id = #{boardId}")
     int deleteCommentsByBoardId(@Param("boardId") Long boardId);
 
+    @Select("select count(*) from Comment where parent_comment_id=#{parentCommentId}")
+    int countChildComments(Long parentCommentId);
+
     // 댓글 삭제 (CASCADE 설정으로 인해 자식 댓글도 자동 삭제됨)
     @Delete("DELETE FROM Comment WHERE comment_id = #{commentId}")
     int deleteComment(@Param("commentId") Long commentId);
+
+    @Update("update Board set comments_count=comments_count-#{commentCount}-1 where board_id=#{boardId}")
+    void deleteCommentCount(@Param("boardId") Long boardId, @Param("commentCount") int commentCount);
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
@@ -28,7 +28,9 @@ public class CommentServiceImpl implements CommentService {
         }
 
         // 댓글 삭제 (CASCADE 설정으로 인해 자식 댓글도 자동 삭제됨)
+        int childCommentCount = commentDAO.countChildComments(commentId);
         commentDAO.deleteComment(commentId);
+        commentDAO.deleteCommentCount(boardId, childCommentCount);
         log.info("댓글 삭제 완료 - commentId: {}", commentId);
     }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/comment/service/CommentServiceImpl.java
@@ -32,5 +32,7 @@ public class CommentServiceImpl implements CommentService {
         commentDAO.deleteComment(commentId);
         commentDAO.deleteCommentCount(boardId, childCommentCount);
         log.info("댓글 삭제 완료 - commentId: {}", commentId);
+
+
     }
 }


### PR DESCRIPTION
## 개요

기존에 프론트에서 좋아요 수, 댓글 수를 직접 계산해서 반환하던 로직을 각각 post 요청이 들어올 때 값을 테이블에 직접 update 해줌

<!---- Resolves: #97 -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

1️⃣ 좋아요 요청/취소 시 board 테이블의 likes_count 필드 값 업데이트
2️⃣ 댓글/대댓글 작성/삭제 시 board 테이블의 comments_count 필드 값 업데이트 
(단, 댓글 삭제 시 대댓글도 함께 삭제되므로 댓글 삭제 전 대댓글 개수 카운트 하고, 댓글 삭제 후 대댓글 개수를 포함해서 댓글 개수 반영)

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).