### PR TITLE
FE : 좋아요/댓글 수 Board정보에서 불러오도록함

### DIFF
--- a/frontend/src/components/BoardCard.js
+++ b/frontend/src/components/BoardCard.js
@@ -11,9 +11,11 @@ import {
   Divider,
 } from '@mui/material';
 import {
-  ThumbUp as ThumbUpIcon,
+  Favorite as FavoriteIcon,
+  FavoriteBorder as FavoriteBorderIcon,
   Visibility as VisibilityIcon,
   AccessTime as AccessTimeIcon,
+  ChatBubbleOutline as ChatBubbleOutlineIcon,
 } from '@mui/icons-material';
 
 const BoardCard = ({ post, categories, onClick }) => {
@@ -106,8 +108,14 @@ const BoardCard = ({ post, categories, onClick }) => {
               </Tooltip>
               <Tooltip title="좋아요">
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                  <ThumbUpIcon fontSize="small" />
+                  <FavoriteIcon fontSize="small" />
                   <Typography variant="body2">{post.likesCount || 0}</Typography>
+                </Box>
+              </Tooltip>
+              <Tooltip title="댓글">
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <ChatBubbleOutlineIcon fontSize="small" />
+                  <Typography variant="body2">{post.commentsCount || 0}</Typography>
                 </Box>
               </Tooltip>
             </Box>

--- a/frontend/src/pages/BoardDetail.js
+++ b/frontend/src/pages/BoardDetail.js
@@ -59,25 +59,16 @@ const BoardDetail = () => {
         setLoading(true);
         setError('');
         
-        // 게시글 상세 정보, 댓글, 좋아요 상태, 좋아요 수를 병렬로 가져옵니다
-        const [boardResponse, commentsResponse, likeResponse, likesCountResponse] = await Promise.all([
+        // 게시글 상세 정보와 좋아요 상태만 가져옵니다
+        const [boardResponse, likeResponse] = await Promise.all([
           BoardService.getBoardDetail(id),
-          BoardService.getBoardComments(id),
-          user ? BoardService.getLikeStatus(id) : Promise.resolve({ data: { isLiked: false } }),
-          BoardService.getLikesCount(id)
+          user ? BoardService.getLikeStatus(id) : Promise.resolve({ data: { isLiked: false } })
         ]);
 
         console.log('게시글 상세 응답:', boardResponse.data);
         console.log('좋아요 상태 응답:', likeResponse.data);
-        console.log('좋아요 수 응답:', likesCountResponse.data);
-        console.log('댓글 조회 응답:', commentsResponse.data);
         
-        setPost({
-          ...boardResponse.data,
-          likesCount: likesCountResponse.data
-        });
-        setComments(commentsResponse.data);
-        console.log('설정할 좋아요 상태:', likeResponse.data.liked);
+        setPost(boardResponse.data);
         setLiked(likeResponse.data.liked);
       } catch (error) {
         console.error('데이터 로딩 실패:', error);
@@ -327,6 +318,9 @@ const BoardDetail = () => {
             </Typography>
             <Typography variant="body2" color="text.secondary">
               좋아요: {post.likesCount}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              댓글: {post.commentsCount}
             </Typography>
           </Box>
         </Box>

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -70,6 +70,7 @@ const MyPage = () => {
     try {
       setLoading(true);
       const response = await axios.get(`/mypages/posts?page=${page - 1}&size=${itemsPerPage}`);
+      console.log('게시글 목록 응답 데이터:', response.data.content); // 각 게시글의 상세 데이터 확인
       setPosts(response.data.content || []);
       setTotalPages(Math.ceil((response.data.totalElements || 0) / itemsPerPage));
     } catch (err) {
@@ -86,6 +87,7 @@ const MyPage = () => {
     try {
       setLoading(true);
       const response = await axios.get(`/mypages/comments?page=${page - 1}&size=${itemsPerPage}`);
+      console.log('댓글 목록 응답:', response.data); // 디버깅용 로그 추가
       setComments(response.data.content || []);
       setTotalPages(Math.ceil((response.data.totalElements || 0) / itemsPerPage));
     } catch (err) {
@@ -102,6 +104,7 @@ const MyPage = () => {
     try {
       setLoading(true);
       const response = await axios.get(`/mypages/likes?page=${page - 1}&size=${itemsPerPage}`);
+      console.log('좋아요 목록 응답 데이터:', response.data.content); // 각 게시글의 상세 데이터 확인
       setLikes(response.data.content || []);
       setTotalPages(Math.ceil((response.data.totalElements || 0) / itemsPerPage));
     } catch (err) {
@@ -300,17 +303,17 @@ const MyPage = () => {
                                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
                                   <Chip
                                     size="small"
-                                    label={`조회수 ${post.views}`}
+                                    label={`조회수 ${post.views || 0}`}
                                     variant="outlined"
                                   />
                                   <Chip
                                     size="small"
-                                    label={`좋아요 ${post.likes_count}`}
+                                    label={`좋아요 ${post.likesCount || 0}`}
                                     variant="outlined"
                                   />
                                   <Chip
                                     size="small"
-                                    label={`댓글 ${post.commentsCount}`}
+                                    label={`댓글 ${post.commentsCount || post.comments_count || 0}`}
                                     variant="outlined"
                                   />
                                   <Typography component="span" variant="body2" color="text.secondary">
@@ -399,6 +402,13 @@ const MyPage = () => {
                               <Typography variant="body2" color="text.secondary">
                                 {formatDate(comment.createAt)}
                               </Typography>
+                              {comment.boardCommentsCount !== undefined && (
+                                <Chip
+                                  size="small"
+                                  label={`댓글 ${comment.boardCommentsCount}`}
+                                  variant="outlined"
+                                />
+                              )}
                             </Box>
                           </Box>
                         </ListItem>
@@ -452,17 +462,17 @@ const MyPage = () => {
                                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
                                   <Chip
                                     size="small"
-                                    label={`조회수 ${post.views}`}
+                                    label={`조회수 ${post.views || 0}`}
                                     variant="outlined"
                                   />
                                   <Chip
                                     size="small"
-                                    label={`좋아요 ${post.likes_count}`}
+                                    label={`좋아요 ${post.likesCount || 0}`}
                                     variant="outlined"
                                   />
                                   <Chip
                                     size="small"
-                                    label={`댓글 ${post.commentsCount}`}
+                                    label={`댓글 ${post.commentsCount || post.comments_count || 0}`}
                                     variant="outlined"
                                   />
                                   <Typography component="span" variant="body2" color="text.secondary">


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #106  -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용
프론트에서 좋아요/댓글 수 Board정보에서 불러오도록 변경
보드카드 디자인 수정 -> 따봉 아이콘에서 하트 아이콘으로

## 스크린샷

댓글 수 표시 및, 좋아요 아이콘 변경.
![image](https://github.com/user-attachments/assets/0ceecd1f-f321-41dd-9473-8c15a908fc5d)

마이페이지에서 자신이 작성한 글/좋아요한 글에도 좋아요수/댓글수 보이도록함(기존 undefined)
![image](https://github.com/user-attachments/assets/e8be0d81-a688-43da-8375-2538f13c92c0)


## 공유사항 to 리뷰어


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).