### PR TITLE
[FE]로그인 두번해야하는 에러 해결/BoardDetail에서 댓글 api호출

### DIFF
--- a/frontend/src/components/OAuthRedirect.js
+++ b/frontend/src/components/OAuthRedirect.js
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 
 export const OAuthRedirect = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { login } = useAuth();
 
   useEffect(() => {
     const handleOAuthRedirect = () => {
@@ -22,18 +24,16 @@ export const OAuthRedirect = () => {
           throw new Error('Required parameters missing');
         }
 
-        // 토큰 저장
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
-        
-        // 사용자 정보 저장
+        // 사용자 정보 객체 생성
         const userInfo = {
           userId,
           nickname,
           role
         };
         console.log('localStorage에 저장할 사용자 정보:', userInfo);
-        localStorage.setItem('user', JSON.stringify(userInfo));
+
+        // AuthContext의 login 함수를 사용하여 로그인 처리
+        login(userInfo, { accessToken, refreshToken });
 
         // 메인 페이지로 리디렉션
         navigate('/');
@@ -44,7 +44,7 @@ export const OAuthRedirect = () => {
     };
 
     handleOAuthRedirect();
-  }, [location, navigate]);
+  }, [location, navigate, login]);
 
   return (
     <div className="flex items-center justify-center min-h-screen">

--- a/frontend/src/pages/BoardDetail.js
+++ b/frontend/src/pages/BoardDetail.js
@@ -59,17 +59,20 @@ const BoardDetail = () => {
         setLoading(true);
         setError('');
         
-        // 게시글 상세 정보와 좋아요 상태만 가져옵니다
-        const [boardResponse, likeResponse] = await Promise.all([
+        // 게시글 상세 정보, 좋아요 상태, 댓글 목록을 병렬로 가져옵니다
+        const [boardResponse, likeResponse, commentsResponse] = await Promise.all([
           BoardService.getBoardDetail(id),
-          user ? BoardService.getLikeStatus(id) : Promise.resolve({ data: { isLiked: false } })
+          user ? BoardService.getLikeStatus(id) : Promise.resolve({ data: { isLiked: false } }),
+          BoardService.getBoardComments(id)
         ]);
 
         console.log('게시글 상세 응답:', boardResponse.data);
         console.log('좋아요 상태 응답:', likeResponse.data);
+        console.log('댓글 목록 응답:', commentsResponse.data);
         
         setPost(boardResponse.data);
         setLiked(likeResponse.data.liked);
+        setComments(commentsResponse.data);
       } catch (error) {
         console.error('데이터 로딩 실패:', error);
         if (error.response) {


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

이전에는 localStorage에만 데이터를 저장하고 AuthContext의 상태를 업데이트하지 않아서, 앱이 처음 마운트될 때 AuthContext가 초기화되면서 로그인 상태가 초기화되는 문제가 있었음.

해결
OAuth 로그인 성공 시 AuthContext의 login 함수를 사용하여 로그인 상태를 관리
login 함수는 토큰과 사용자 정보를 localStorage에 저장하고, AuthContext의 상태도 업데이트

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).