### PR TITLE
[BE] BoardResponseDto에 게시글 내용과 이미지 추가

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                                 "/api/auth/**", // 인증 관련 API (로그인 시작, 콜백 등)
                                 "/api/foods", // 음식 검색 (GET) - 명세상 모든 사용자 접근 가능
                                 "/api/foods/{foodId}", // 음식 상세 조회 (GET) - 명세상 모든 사용자 접근 가능
-                                "/api/boards", // 게시판 목록 조회 (GET)
+                                "/api/boards/**", // 게시판 목록 조회 (GET)
                                 "/api/boards/{boardId}" // 게시판 상세 조회 (GET)
                                 // 필요시 h2-console 접근 허용 (개발용)
                                 // , "/h2-console/**"
@@ -68,10 +68,10 @@ public class SecurityConfig {
                         .hasRole("ADMIN") // ADMIN 역할 필요
 
                         .requestMatchers(
-                                "/api/users/me/**", // 내 정보 관련
+                                "/api/mypages/**", // 내 정보 관련
                                 "/api/meallogs/**", // 식단 기록 관련
                                 "/api/food-requests", // 음식 요청 (POST)
-                                "/api/board" // 게시글 작성(POST), 수정(PUT), 삭제(DELETE) - 세부 검증은 컨트롤러/서비스에서
+                                "/api/boards/**" // 게시글 작성(POST), 수정(PUT), 삭제(DELETE) - 세부 검증은 컨트롤러/서비스에서
                         ).hasAnyRole("USER", "ADMIN") // USER 또는 ADMIN 역할 필요
 //                        ).hasAuthority("USER") // JWT에 "USER"라고 넣었을 때만 일치
 

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/controller/BoardController.java
@@ -177,6 +177,7 @@ public class BoardController {
     * POST api/boards/{boardId}/comments
     * 접근 권한 : USER */
     @PostMapping("/{boardId}/comments")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> createComment(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long boardId,
@@ -189,7 +190,7 @@ public class BoardController {
 
     }
 
-    /* 게시글 내의 댓글/대댓글(1개) 조회
+    /* 게시글 내의 댓글/대댓글 조회
      * GET api/boards/{boardId}/comments
      * 접근 권한 : ALL */
     @GetMapping("/{boardId}/comments")

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardDAO.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dao/BoardDAO.java
@@ -24,7 +24,17 @@ public interface BoardDAO {
                 b.update_at as updateAt,
                 b.views as views,
                 b.likes_count as likes_count,
-                b.comments_count as commentsCount
+                b.comments_count as commentsCount,
+                (SELECT blk.content_text 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="text" 
+                Order by order_index 
+                Limit 1) as content, 
+                (SELECT blk.image_url 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="image" 
+                Order by order_index 
+                Limit 1) as imageUrl 
             FROM
                 Board b
             INNER JOIN
@@ -93,7 +103,17 @@ public interface BoardDAO {
                 b.update_at as updateAt,
                 b.views as views,
                 b.likes_count as likes_count,
-                b.comments_count as commentsCount
+                b.comments_count as commentsCount,
+                (SELECT blk.content_text 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="text" 
+                Order by order_index 
+                Limit 1) as content, 
+                (SELECT blk.image_url 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="image" 
+                Order by order_index 
+                Limit 1) as imageUrl
             FROM
                 Board b
             INNER JOIN
@@ -146,7 +166,17 @@ public interface BoardDAO {
                 b.update_at as updateAt,
                 b.views as views,
                 b.likes_count as likes_count,
-                b.comments_count as commentsCount
+                b.comments_count as commentsCount,
+                (SELECT blk.content_text 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="text" 
+                Order by order_index 
+                Limit 1) as content, 
+                (SELECT blk.image_url 
+                From Block blk 
+                Where blk.board_id = b.board_id And blk.block_type="image" 
+                Order by order_index 
+                Limit 1) as imageUrl
             FROM
                 Board b
             INNER JOIN

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/BoardResponseDto.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/board/dto/BoardResponseDto.java
@@ -20,4 +20,6 @@ public class BoardResponseDto {
     private int views; // 조회수
     private int likesCount; // 좋아요 수
     private int commentsCount; // 댓글 수
+    private String content; // 내용
+    private String imageUrl; // 이미지
 }


### PR DESCRIPTION
## 개요

ecurityConfig 인가 규칙 수정
- get 요청 허요 api/boards 루트를 api/board/**으로 변경 (/boards/search/** 같은 루트는 인식을 못 함)

<!---- Resolves: #110  -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

게시글 반환 시 기존에는 게시글 테이블의 내용을 반환했으나 게시글 내용과 이미지를 추가로 반환하도록 쿼리문 수정
- null이라면 null을 반환
- 블록 테이블의 board_id가 일치하는 데이터를 오름차순으로 정렬 후 1개의 값만 반환
- block_type : text or image 로 구분

## 스크린샷

<img width="828" alt="image" src="https://github.com/user-attachments/assets/1f2eae06-e607-4a4c-aa59-8861d42c1d48" />

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).