### PR TITLE
[BE] 메인페이지 음식 추천 요청 redis로 cache 구현

### DIFF
--- a/Backend/build.gradle
+++ b/Backend/build.gradle
@@ -54,6 +54,11 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // 버전은 프로젝트 환경에 맞게 최신 확인
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// LocalTime 타입 JSON으로 직렬화/역직렬화
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 tasks.named('test') {

--- a/Backend/src/main/java/com/ssafy/HappyMealApplication.java
+++ b/Backend/src/main/java/com/ssafy/HappyMealApplication.java
@@ -3,8 +3,10 @@ package com.ssafy;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling // 스케줄링 활성화
 //@MapperScan("com.ssafy.happymeal.domain.user.dao")
 public class HappyMealApplication {
 

--- a/Backend/src/main/java/com/ssafy/happymeal/config/RedisConfig.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/config/RedisConfig.java
@@ -1,0 +1,68 @@
+package com.ssafy.happymeal.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.ssafy.happymeal.domain.food.entity.Food; // Food 엔티티/DTO 경로
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer; // 변경된 시리얼라이저
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import java.util.List;
+
+@Configuration
+public class RedisConfig {
+
+    /**
+     * 애플리케이션 전반에서 사용될 수 있는 ObjectMapper를 Spring Bean으로 등록합니다.
+     * JavaTimeModule을 등록하여 Java 8+ 날짜/시간 타입을 지원하고,
+     * 날짜/시간을 타임스탬프 대신 ISO-8601 문자열 형식으로 직렬화하도록 설정합니다.
+     * @Primary 어노테이션을 사용하여 다른 ObjectMapper 빈보다 우선적으로 사용되도록 합니다.
+     */
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 역직렬화 시 구체적인 타입을 알 수 있도록 기본 타이핑 활성화 (선택 사항, 보안 고려 필요)
+        // GenericJackson2JsonRedisSerializer가 타입을 잘 처리한다면 필요 없을 수 있습니다.
+        // 필요에 따라 아래 주석을 해제하고 특정 패키지 등으로 범위를 제한하는 것이 좋습니다.
+        // PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+        // .allowIfSubType("com.ssafy.happymeal") // 허용할 패키지 지정 (보안 강화)
+        // .allowIfSubType("java.util.ArrayList")
+        // .build();
+        // objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        return objectMapper;
+    }
+
+    @Bean
+    public RedisTemplate<String, List<Food>> redisTemplateListFood(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) { // Spring 컨텍스트에서 ObjectMapper 빈 주입
+        RedisTemplate<String, List<Food>> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // 키 직렬화: StringRedisSerializer 사용
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // 값 직렬화: GenericJackson2JsonRedisSerializer 사용 및 주입된 ObjectMapper 전달
+        // GenericJackson2JsonRedisSerializer는 생성자에서 ObjectMapper를 받으므로,
+        // 우리가 설정한 JavaTimeModule 등이 포함된 ObjectMapper가 확실하게 사용됩니다.
+        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setValueSerializer(genericJackson2JsonRedisSerializer);
+
+        // 해시 키/값 직렬화 방식도 동일하게 설정
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(genericJackson2JsonRedisSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodService.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodService.java
@@ -63,4 +63,5 @@ public interface FoodService {
     List<Food> getRecommendedFoods(String categoryName); // 반환 타입 변경
 
 
+
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodServiceImpl.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/food/service/FoodServiceImpl.java
@@ -4,58 +4,61 @@ import com.ssafy.happymeal.domain.food.dao.FoodDAO;
 import com.ssafy.happymeal.domain.food.dto.FoodNameSearchCriteria;
 import com.ssafy.happymeal.domain.food.dto.FoodPagingSortCriteria;
 import com.ssafy.happymeal.domain.food.entity.Food;
+import com.ssafy.happymeal.util.CacheConstants; // 1-2 단계에서 만든 캐시 상수 클래스
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page; // Spring Data Page
-import org.springframework.data.domain.PageImpl; // Spring Data Page 구현체
-import org.springframework.data.domain.PageRequest; // 페이징 정보 객체
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate; // RedisTemplate import
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils; // StringUtils 사용
+import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
+import java.util.Collections; // Collections.emptyList() 사용을 위해 import
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set; // 허용된 정렬 필드 검증용
+import java.util.Set;
+import java.util.concurrent.TimeUnit; // TimeUnit import
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
+@RequiredArgsConstructor // final 필드에 대한 생성자 자동 주입
+@Transactional(readOnly = true) // 클래스 레벨 트랜잭션 (읽기 전용)
 public class FoodServiceImpl implements FoodService {
 
-    private final FoodDAO foodDAO;
-    private static final int MAX_PAGE_SIZE = 100; // 최대 페이지 크기 제한
+    private final FoodDAO foodDAO; // 기존 의존성
+    private final RedisTemplate<String, List<Food>> redisTemplateListFood; // 새로 추가된 의존성 (1-1 단계에서 설정)
 
-    // 허용된 정렬 필드명 (SQL Injection 방지용 화이트리스트)
+    private static final int MAX_PAGE_SIZE = 100;
     private static final Set<String> ALLOWED_SORT_FIELDS = Set.of("name", "calories", "protein", "fat", "sugar", "carbs", "category", "create_at", "update_at");
+
+    // 메인 페이지 추천에 사용할 기본 카테고리 (이 값은 스케줄러에서도 동일하게 사용될 수 있습니다)
+    private static final String MAIN_PAGE_CATEGORY_1 = "healthy";
+    private static final String MAIN_PAGE_CATEGORY_2 = "diet";
+    private static final String MAIN_PAGE_CATEGORY_3 = "healthy";
+//    private static final String DEFAULT_MAIN_PAGE_CATEGORY = "healthy"; // 예시로 "healthy" 카테고리 사용
+
+    // 캐시 동시 업데이트 방지를 위한 락(lock) 객체
+//    private final Object cacheUpdateLock = new Object();
+
 
     private String buildOrderByClause(String sortByWithDirection) {
         if (!StringUtils.hasText(sortByWithDirection)) {
             return "name ASC"; // 기본 정렬
         }
-        // 예: "name,calories DESC" -> "name ASC, calories DESC"
-        // sortBy=name:asc,calories:desc
         StringBuilder orderByClause = new StringBuilder();
         String[] sortParams = sortByWithDirection.split(",");
         for (String sortParam : sortParams) {
-            String[] parts = sortParam.trim().split("\\s+"); // 공백 기준 분리 또는 ":" 기준 분리
+            String[] parts = sortParam.trim().split("\\s+");
             String field = parts[0].toLowerCase();
             String direction = (parts.length > 1 && "desc".equalsIgnoreCase(parts[1])) ? "DESC" : "ASC";
 
             if (ALLOWED_SORT_FIELDS.contains(field)) {
-                // DB 컬럼명으로 변환 (필요시)
-                // 예: create_at -> createdAt, 여기서는 mapUnderscoreToCamelCase가 DB->Java, Java->DB는 아니므로 직접 사용
-                // DB 컬럼명이 스네이크 케이스라면 필드명도 스네이크로 변환해야 함.
-                // 여기서는 params.orderByClause에 Java 필드명 기준(카멜)으로 넣고, DB가 알아서 매핑하도록 하거나
-                // 아니면 DB 컬럼명 기준으로만 정렬 가능하도록 명시. 여기서는 DB 컬럼명 기준 가정
-                String dbColumn = field; // 간단히 Java 필드명=DB 컬럼명(스네이크 변환 후) 가정
-                // 만약 Java 필드명(카멜)을 DB 컬럼명(스네이크)으로 변환해야 한다면 로직 추가
-                // 예를 들어 field "createdAt" -> DB "create_at"
-
+                String dbColumn = field;
                 if (orderByClause.length() > 0) {
                     orderByClause.append(", ");
                 }
@@ -64,16 +67,15 @@ public class FoodServiceImpl implements FoodService {
                 log.warn("Invalid sort field provided: {}. Ignoring.", field);
             }
         }
-        return orderByClause.length() > 0 ? orderByClause.toString() : "name ASC"; // 유효한 정렬 없으면 기본값
+        return orderByClause.length() > 0 ? orderByClause.toString() : "name ASC";
     }
-
 
     @Override
     public Page<Food> searchFoodsByName(FoodNameSearchCriteria criteria) {
         log.info("음식 이름 검색 서비스: name={}, sortBy={}, page={}, size={}",
                 criteria.getName(), criteria.getSortBy(), criteria.getPage(), criteria.getSize());
 
-        int pageSize = Math.min(criteria.getSize(), MAX_PAGE_SIZE); // 페이지 크기 제한
+        int pageSize = Math.min(criteria.getSize(), MAX_PAGE_SIZE);
         int offset = criteria.getPage() * pageSize;
 
         Map<String, Object> params = new HashMap<>();
@@ -107,7 +109,6 @@ public class FoodServiceImpl implements FoodService {
         return new PageImpl<>(foods, PageRequest.of(criteria.getPage(), pageSize), totalElements);
     }
 
-    // --- 기존 단건 조회, CUD, 추천 API용 서비스 메소드는 유지 ---
     @Override
     public Food getFoodById(Long foodId) {
         return foodDAO.findById(foodId)
@@ -115,10 +116,10 @@ public class FoodServiceImpl implements FoodService {
     }
 
     @Override
-    @Transactional // 쓰기 작업
+    @Transactional // 쓰기 작업이므로 readOnly = false 적용
     public Food addFood(Food food) {
         foodDAO.save(food);
-        return food; // foodId가 설정된 객체
+        return food;
     }
 
     @Override
@@ -126,10 +127,10 @@ public class FoodServiceImpl implements FoodService {
     public Food updateFood(Long foodId, Food foodDetailsToUpdate) {
         foodDAO.findById(foodId)
                 .orElseThrow(() -> new EntityNotFoundException("Food not found with id: " + foodId + ". Cannot update."));
-        foodDetailsToUpdate.setFoodId(foodId); // ID 설정 확실히
+        foodDetailsToUpdate.setFoodId(foodId);
         int affectedRows = foodDAO.update(foodDetailsToUpdate);
         if (affectedRows == 0) throw new RuntimeException("Food update failed for id: " + foodId);
-        return foodDAO.findById(foodId).orElseThrow(); // 업데이트된 정보 다시 조회
+        return foodDAO.findById(foodId).orElseThrow();
     }
 
     @Override
@@ -140,38 +141,91 @@ public class FoodServiceImpl implements FoodService {
         foodDAO.delete(foodId);
     }
 
+    /**
+     * 특정 카테고리에 해당하는 추천 음식 목록을 가져옵니다.
+     * 먼저 Redis 캐시를 확인하고, 없으면 DB에서 조회 후 카테고리별 영양소 기준을 Map에 담아 DAO를 호출
+     * 그리고 마지막으로 캐시에 저장하고 반환합니다.
+     */
     @Override
     public List<Food> getRecommendedFoods(String categoryName) {
-        log.info("Fetching simplified recommendations for category: {}", categoryName);
-        Map<String, Object> params = new HashMap<>();
-        // 카테고리별 영양소 기준치 설정 ... (이전 답변과 동일)
-        switch (categoryName.toLowerCase()) {
-            case "diet":
-                params.put("maxCalories", new BigDecimal("150"));
-                params.put("minProtein", new BigDecimal("10"));
-                params.put("maxFat", new BigDecimal("10").subtract(BigDecimal.valueOf(0.01)));
-                params.put("maxSugar", new BigDecimal("5").subtract(BigDecimal.valueOf(0.01)));
-                break;
-            case "healthy":
-                params.put("minCalories", new BigDecimal("100"));
-                params.put("maxCalories", new BigDecimal("250"));
-                params.put("minProtein", new BigDecimal("10"));
-                params.put("minFat", new BigDecimal("5"));
-                params.put("maxFat", new BigDecimal("15"));
-                params.put("maxSugar", new BigDecimal("10").subtract(BigDecimal.valueOf(0.01)));
-                break;
-            case "bulk-up":
-                params.put("minCalories", new BigDecimal("200"));
-                params.put("minProtein", new BigDecimal("15"));
-                params.put("minFat", new BigDecimal("10"));
-                break;
-            case "cheating":
-                params.put("minCalories", new BigDecimal("400"));
-                break;
-            default:
-                log.warn("Unknown category for simplified recommendation: {}.", categoryName);
-                break;
+        // 1. 카테고리명을 기반으로 동적 캐시 키 생성
+        String cacheKey = CacheConstants.RECOMMENDATIONS_KEY_PRIPIX + categoryName.toLowerCase();
+
+        log.debug("카테고리 '{}' 추천 음식 요청: 캐시 확인 시작 (Key: {})", categoryName, cacheKey);
+        List<Food> recommendations;
+
+        // 2. Redis 캐시에서 데이터 조회 시도
+        try {
+            recommendations = redisTemplateListFood.opsForValue().get(cacheKey);
+        } catch (Exception e) {
+            log.error("Redis 캐시 조회 중 오류 발생! DB에서 직접 조회 시도. (Key: {})", cacheKey, e);
+            recommendations = null; // 오류 발생 시 캐시 미스로 간주
         }
-        return foodDAO.findRecommendFoods(params); // DAO는 이미 랜덤 3개 반환
+
+        if (recommendations == null) { // 3. 캐시 미스(Cache Miss) 발생!
+            log.warn("캐시 미스 발생 (Key: {}). DB에서 조회하여 캐시를 업데이트합니다.", cacheKey);
+
+            // --- DB 조회 로직 (기존 getRecommendedFoods 로직과 동일) ---
+            Map<String, Object> params = new HashMap<>();
+            switch (categoryName.toLowerCase()) {
+                case "diet":
+                    params.put("maxCalories", new BigDecimal("150"));
+                    params.put("minProtein", new BigDecimal("10"));
+                    params.put("maxFat", new BigDecimal("10").subtract(BigDecimal.valueOf(0.01)));
+                    params.put("maxSugar", new BigDecimal("5").subtract(BigDecimal.valueOf(0.01)));
+                    break;
+                case "healthy":
+                    params.put("minCalories", new BigDecimal("100"));
+                    params.put("maxCalories", new BigDecimal("250"));
+                    params.put("minProtein", new BigDecimal("10"));
+                    params.put("minFat", new BigDecimal("5"));
+                    params.put("maxFat", new BigDecimal("15"));
+                    params.put("maxSugar", new BigDecimal("10").subtract(BigDecimal.valueOf(0.01)));
+                    break;
+                case "bulk-up":
+                    params.put("minCalories", new BigDecimal("200"));
+                    params.put("minProtein", new BigDecimal("15"));
+                    params.put("minFat", new BigDecimal("10"));
+                    break;
+                case "cheating":
+                    params.put("minCalories", new BigDecimal("400"));
+                    break;
+                default:
+                    log.warn("알 수 없는 추천 카테고리 '{}' (Key: {}). 빈 리스트를 반환합니다.", categoryName, cacheKey);
+                    return Collections.emptyList(); // 유효하지 않은 카테고리는 빈 리스트 반환
+            }
+            log.info("DB에서 카테고리 '{}'에 대한 추천 음식 조회 중... (Key: {})", categoryName, cacheKey);
+            recommendations = foodDAO.findRecommendFoods(params); // DAO는 랜덤 3개를 반환한다고 가정
+
+            if (recommendations == null) { // DAO가 null을 반환할 수 있다면 NPE 방지
+                recommendations = Collections.emptyList();
+            }
+            // --- DB 조회 로직 끝 ---
+
+            // 4. DB 조회 결과를 캐시에 저장 (결과가 비어있지 않은 경우에만)
+            if (!recommendations.isEmpty()) {
+                try {
+                    redisTemplateListFood.opsForValue().set(cacheKey, recommendations, 25, TimeUnit.HOURS);
+                    log.info("카테고리 '{}'의 추천 음식 ({}개)을 Redis 캐시에 성공적으로 저장했습니다. (Key: {})", categoryName, recommendations.size(), cacheKey);
+                } catch (Exception e) {
+                    log.error("Redis 캐시에 추천 음식 저장 중 오류 발생 (Key: {})!", cacheKey, e);
+                    // 캐시 저장 실패 시에도 DB에서 가져온 데이터는 반환해야 하므로, 여기서 반환하지 않음.
+                }
+            } else {
+                log.info("카테고리 '{}'에 대한 추천 음식을 DB에서 찾을 수 없거나 비어있어 캐시하지 않습니다. (Key: {})", categoryName, cacheKey);
+                // 비어 있는 결과라도 짧은 시간 동안 캐싱하여 반복적인 DB 조회를 막을 수도 있습니다. (선택 사항)
+                // 예: redisTemplateListFood.opsForValue().set(cacheKey, Collections.emptyList(), 5, TimeUnit.MINUTES);
+            }
+            log.info("DB에서 조회한 데이터로 응답하고 캐시를 업데이트했습니다. (Key: {})", cacheKey);
+
+        } else { // 5. 캐시 히트(Cache Hit)!
+            log.info("캐시 히트! Redis 캐시에서 카테고리 '{}' 추천 음식을 제공합니다. ({}개 항목, Key: {})", categoryName, recommendations.size(), cacheKey);
+        }
+
+        // 동시성 문제를 고려하지 않기로 했으므로, 락(lock) 관련 코드는 포함하지 않음
+        // 만약 트래픽이 매우 많아 캐시 미스 시 동일 카테고리에 대한 동시 DB 접근이 우려된다면,
+        // 이전에 논의했던 `synchronized` 블록이나 분산 락 등을 고려
+
+        return recommendations;
     }
 }

--- a/Backend/src/main/java/com/ssafy/happymeal/scheduler/RecommendationScheduler.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/scheduler/RecommendationScheduler.java
@@ -1,0 +1,63 @@
+package com.ssafy.happymeal.scheduler;
+
+import com.ssafy.happymeal.domain.food.service.FoodService; // FoodService 인터페이스 경로
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j // Lombok을 사용하여 로깅 기능을 쉽게 추가합니다.
+@Component // 이 클래스를 Spring이 관리하는 컴포넌트로 등록합니다.
+@RequiredArgsConstructor // final 필드에 대한 생성자를 자동으로 만들어 의존성을 주입합니다.
+public class RecommendationScheduler {
+
+    private final FoodService foodService; // FoodService를 주입받아 캐시 업데이트 작업을 위임합니다.
+
+    // 주기적으로 캐시를 예열(warm-up)할 대상 카테고리 목록입니다.
+    // 프론트엔드에서 주로 사용하는 카테고리들을 여기에 포함시킬 수 있습니다.
+    // 이 목록은 설정 파일(application.properties 또는 yml)에서 읽어오도록 개선할 수도 있습니다.
+    private static final List<String> TARGET_CATEGORIES_FOR_WARMING = Arrays.asList(
+            "diet",
+            "healthy",
+            "bulk-up",
+            "cheating"
+            // 필요에 따라 다른 주요 카테고리 추가
+    );
+
+    /**
+     * 매일 새벽 2시에 실행되어 주요 카테고리들의 추천 음식 캐시를 갱신합니다.
+     * cron 표현식: "초 분 시 일 월 요일" (연도는 생략 가능)
+     * "0 0 2 * * ?" 의미: 매일(어떤 요일이든), 어떤 달이든, 어떤 날이든, 새벽 2시 0분 0초에 실행
+     */
+    @Scheduled(cron = "0 0 2 * * ?") // 매일 새벽 2시에 실행
+    // 테스트를 위해 짧은 주기로 변경 가능: 예) "0 */5 * * * ?" (매 5분마다 0초에 실행)
+    public void refreshRecommendationCache() {
+        log.info("추천 음식 캐시 갱신 스케줄 작업 시작...");
+
+        for (String categoryName : TARGET_CATEGORIES_FOR_WARMING) {
+            try {
+                log.info("카테고리 '{}'에 대한 캐시 갱신 시도...", categoryName);
+                // FoodService의 getRecommendedFoods 메서드를 호출합니다.
+                // 이 메서드 내부에 캐시 조회, DB 조회, 캐시 저장 로직이 모두 포함되어 있으므로,
+                // 단순히 호출하는 것만으로 캐시가 채워지거나 갱신됩니다.
+                foodService.getRecommendedFoods(categoryName);
+                log.info("카테고리 '{}' 캐시 갱신 성공 또는 이미 최신 상태임.", categoryName);
+            } catch (Exception e) {
+                // 특정 카테고리 처리 중 예외가 발생하더라도 다른 카테고리 처리는 계속 진행되도록 합니다.
+                log.error("카테고리 '{}' 캐시 갱신 중 오류 발생!", categoryName, e);
+            }
+        }
+        log.info("추천 음식 캐시 갱신 스케줄 작업 완료.");
+    }
+
+    // (선택 사항) 애플리케이션 시작 시 한번 캐시를 채우는 로직 추가 가능
+    // @PostConstruct
+    // public void initRecommendationCacheOnStartup() {
+    //    log.info("애플리케이션 시작 시 추천 음식 캐시 초기화 작업 시작...");
+    //    refreshRecommendationCache(); // 위 스케줄링 메서드 재활용
+    //    log.info("애플리케이션 시작 시 추천 음식 캐시 초기화 작업 완료.");
+    // }
+}

--- a/Backend/src/main/java/com/ssafy/happymeal/util/CacheConstants.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/util/CacheConstants.java
@@ -1,0 +1,5 @@
+package com.ssafy.happymeal.util;
+
+public class CacheConstants {
+    public static final String RECOMMENDATIONS_KEY_PRIPIX = "recommendations:";
+}


### PR DESCRIPTION
## 개요

사용자에게 더 빠르고 안정적으로 음식 추천 정보를 제공하기 위해, 카테고리별 추천 음식 조회 API에 Redis 캐싱 및 일일 자동 업데이트 스케줄링 기능을 도입

<!---- Resolves: #123 -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

1️⃣ 기존의 DB 호출 대신, 각 음식 카테고리(예: diet, healthy 등)별로 추천 데이터를 개별적으로 캐싱하도록 변경
캐시 키는 recommendations:{categoryName} (예: recommendations:diet) 형태로 동적으로 생성됩니다. (CacheConstants.java에 RECOMMENDATIONS_KEY_PREFIX 추가)

2️⃣ List<Food> 객체를 JSON 형태로 Redis에 저장하고 읽어올 수 있도록 Jackson2JsonRedisSerializer를 사용하는 커스텀 RedisTemplate<String, List<Food>> 빈을 설정했습니다.
일일 캐시 업데이트 스케줄러 (RecommendationScheduler.java):

3️⃣ 매일 특정 시간(예: 새벽 2시)에 주요 음식 카테고리들에 대해 foodService.getRecommendedFoods(categoryName)를 자동으로 호출하는 스케줄러를 추가
이를 통해 캐시를 미리 준비(Cache Warming)하여 사용자 요청 시 캐시 히트율을 높이고, "하루에 한 번 데이터 갱신" 요구사항을 만족

## 스크린샷

**스케줄러에 의한 데이터 캐시 저장**
<img width="794" alt="스크린샷 2025-05-24 오후 7 42 56" src="https://github.com/user-attachments/assets/d79ca701-b494-45a9-a261-ac6f99d82319" />

**음식 추천 요청 시 캐시에 저장된 데이터 반환**
<img width="757" alt="스크린샷 2025-05-24 오후 7 43 12" src="https://github.com/user-attachments/assets/67e31352-38e2-47c7-8dfc-5ecd53639512" />

## 공유사항 to 리뷰어

.env 파일에 Redis 서버 연결 정보(호스트, 포트)를 설정
메인 애플리케이션 클래스에 @EnableScheduling 어노테이션을 추가하여 스케줄링 기능을 활성화함.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).