### PR TITLE
밀로그 수정시, imgUrl이 null일 때 발생하는 에러 해결

### DIFF
--- a/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
+++ b/Backend/src/main/java/com/ssafy/happymeal/domain/meallog/service/MealLogServiceIml.java
@@ -157,15 +157,17 @@ public class MealLogServiceIml implements MealLogService{
         // 2. 요청 DTO에 이미지 URL이 제공되지 않았거나 빈 문자열("")인 경우:
         else {
             if(newFood != null) { // food가 변경되었다면 새 food의 이미지 url을 받음
-                if(!newFood.getImgUrl().equals(mealLog.getImgUrl()))
-                if(!Objects.equals(newFood.getImgUrl(), mealLog.getImgUrl())) {
-                    updateImgUrl = newFood.getImgUrl();
+                // food의 이미지가 없는 경우도 허용
+                String newFoodImgUrl = newFood.getImgUrl();
+                // 기존 이미지와 새 이미지가 다른 경우에만 업데이트
+                if(!Objects.equals(newFoodImgUrl, mealLog.getImgUrl())) {
+                    updateImgUrl = newFoodImgUrl; // null이어도 허용
                     isChanged = true;
                 }
             }
         }
 
-        mealLog.setImgUrl(updateImgUrl); // 최종으로 결정된 이미지url 저장
+        mealLog.setImgUrl(updateImgUrl); // 최종으로 결정된 이미지url 저장 (null 허용)
 
         // 5.  변경사항이 있을 경우에만 DB 업데이트
         if(isChanged) {


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업 내용

MealLogServiceIml의 updateMealLog 메서드에서 imgUrl 처리 로직 수정
food의 이미지가 없는 경우(null) 허용
수정 요청에서 이미지를 제공하지 않는 경우 허용
Objects.equals()를 사용하여 null-safe 비교 구현

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 공유사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).